### PR TITLE
Updating objects

### DIFF
--- a/Analysis/HiggsTauTau/interface/Phys14Plots.h
+++ b/Analysis/HiggsTauTau/interface/Phys14Plots.h
@@ -3,7 +3,10 @@
 
 #include "Core/interface/TreeEvent.h"
 #include "Core/interface/ModuleBase.h"
+#include "UserCode/ICHiggsTauTau/interface/PFCandidate.hh"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
+#include "UserCode/ICHiggsTauTau/interface/Track.hh"
+#include "UserCode/ICHiggsTauTau/interface/Vertex.hh"
 #include "TH1F.h"
 #include "TH2F.h"
 
@@ -29,6 +32,49 @@ struct EfficiencyPlot1D {
                    double lo, double hi) {
     all = dir->make<TH1F>((name + "_all").c_str(), "", nbins, lo, hi);
     pass = dir->make<TH1F>((name + "_pass").c_str(), "", nbins, lo, hi);
+  }
+};
+
+struct PFMatchPlot {
+  TH1F* all;
+  TH1F* hadron;
+  TH1F* electron;
+  TH1F* muon;
+  TH1F* photon;
+  TH1F* none;
+
+  PFMatchPlot() {
+    all = nullptr;
+    hadron = nullptr;
+    electron = nullptr;
+    muon = nullptr;
+    photon = nullptr;
+    none = nullptr;
+  }
+
+  void Fill(double val, PFType type) {
+    all->Fill(val);
+    if (type == PFType::h) {
+      hadron->Fill(val);
+    } else if (type == PFType::e) {
+      electron->Fill(val);
+    } else if (type == PFType::mu) {
+      muon->Fill(val);
+    } else if (type == PFType::gamma) {
+      photon->Fill(val);
+    } else {
+      none->Fill(val);
+    }
+  }
+
+  PFMatchPlot(TFileDirectory *dir, std::string const &name, unsigned nbins,
+                   double lo, double hi) {
+    all = dir->make<TH1F>((name + "_all").c_str(), "", nbins, lo, hi);
+    hadron = dir->make<TH1F>((name + "_hadron").c_str(), "", nbins, lo, hi);
+    electron = dir->make<TH1F>((name + "_electron").c_str(), "", nbins, lo, hi);
+    muon = dir->make<TH1F>((name + "_muon").c_str(), "", nbins, lo, hi);
+    photon = dir->make<TH1F>((name + "_photon").c_str(), "", nbins, lo, hi);
+    none = dir->make<TH1F>((name + "_none").c_str(), "", nbins, lo, hi);
   }
 };
 
@@ -117,6 +163,15 @@ class Phys14Plots : public ModuleBase {
   TH1F *h_th1_pt_resp;
   TH1F *h_th10_pt_resp;
 
+  PFMatchPlot th_pf_match_pt;
+  PFMatchPlot th_pf_match_eta;
+  PFMatchPlot th0_pf_match_pt;
+  PFMatchPlot th0_pf_match_eta;
+  PFMatchPlot th1_pf_match_pt;
+  PFMatchPlot th1_pf_match_eta;
+  PFMatchPlot th10_pf_match_pt;
+  PFMatchPlot th10_pf_match_eta;
+
   CLASS_MEMBER(Phys14Plots, fwlite::TFileService*, fs)
 
  public:
@@ -127,6 +182,7 @@ class Phys14Plots : public ModuleBase {
   virtual int Execute(TreeEvent *event);
   virtual int PostAnalysis();
   virtual void PrintInfo();
+  bool QualityTrack(Track const* trk, Vertex const* vtx);
 };
 
 }

--- a/Analysis/HiggsTauTau/macros/plotPFMatch.C
+++ b/Analysis/HiggsTauTau/macros/plotPFMatch.C
@@ -1,0 +1,70 @@
+#include "../../Core/interface/Plotting.h"
+#include "../../Core/interface/Plotting_Style.h"
+
+void plotPFMatch(TString file, TString hist, TString output, TString title,
+                 TString xaxis) {
+  ModTDRStyle();
+  TFile f(file);
+
+  TH1F *h_all = (TH1F*)gDirectory->Get(hist+"_all");
+  TH1F *h_hadron = (TH1F*)gDirectory->Get(hist+"_hadron");
+  TH1F *h_electron = (TH1F*)gDirectory->Get(hist+"_electron");
+  TH1F *h_muon = (TH1F*)gDirectory->Get(hist+"_muon");
+  TH1F *h_photon = (TH1F*)gDirectory->Get(hist+"_photon");
+  TH1F *h_none = (TH1F*)gDirectory->Get(hist+"_none");
+
+  // Convert hists to ratios
+  h_hadron->Divide(h_all);
+  h_electron->Divide(h_all);
+  h_muon->Divide(h_all);
+  h_photon->Divide(h_all);
+  h_none->Divide(h_all);
+
+  h_hadron->SetFillColor(17);
+  h_electron->SetFillColor(38);
+  h_muon->SetFillColor(30);
+  h_photon->SetFillColor(46);
+  h_none->SetFillColor(40);
+
+  THStack stack;
+  stack.Add(h_hadron);
+  stack.Add(h_photon);
+  stack.Add(h_electron);
+  stack.Add(h_muon);
+  stack.Add(h_none);
+
+  TCanvas * canv = new TCanvas("th_mode_table", "th_mode_table");
+  canv->cd();
+  std::vector<TPad*> pads = OnePad();
+
+  // Do the axis hist
+  TH1 *axis = CreateAxisHist(h_all);
+  axis->GetXaxis()->SetTitle(xaxis);
+  axis->GetYaxis()->SetTitle("Fraction");
+  axis->Draw();
+
+  // Draw the stack
+  stack.Draw("HISTSAME");
+
+  // Fix the y-axis range
+  FixTopRange(pads[0], 1.0, 0.0);
+
+  // Make the legend
+  TLegend *leg = PositionedLegend(0.3, 0.3, 6, 0.025);
+  leg->AddEntry(h_none, "None", "F");
+  leg->AddEntry(h_muon, "Muons", "F");
+  leg->AddEntry(h_electron, "Electrons", "F");
+  leg->AddEntry(h_photon, "Photons", "F");
+  leg->AddEntry(h_hadron, "Ch. Hadrons", "F");
+  leg->Draw();
+
+  // Draw labels and text
+  DrawCMSLogo(pads[0], "CMS", "Simulation", 0);
+  DrawTitle(pads[0], title, 3);
+
+  // Redraw the axis
+  FixOverlay();
+
+  // Print!
+  canv->Print(output+".pdf");
+}

--- a/Analysis/HiggsTauTau/scripts/Jan19.json
+++ b/Analysis/HiggsTauTau/scripts/Jan19.json
@@ -1,0 +1,9 @@
+{
+  "job": {
+    "file_prefix": "/Volumes/HDD/Jan19/",
+    "output_folder": "output/phys14/Jan19/",
+    // "output_folder": "./",
+    "max_events": -1,
+    "timings": false
+  }
+}

--- a/Analysis/HiggsTauTau/scripts/phys14_plot_effs.sh
+++ b/Analysis/HiggsTauTau/scripts/phys14_plot_effs.sh
@@ -84,11 +84,11 @@ FRAGMENTS=(
   # '{"output":"th1_dm_eff_vs_ot_pu", "x_axis_title":"Pileup (BX#pm1)", "y_axis_title":"DM Efficiency", "default":{"rebin":"0.5-100.5:4"}}'
   # '{"output":"th10_dm_eff_vs_ot_pu", "x_axis_title":"Pileup (BX#pm1)", "y_axis_title":"DM Efficiency", "default":{"rebin":"0.5-100.5:4"}}'
   # Special plots
-  '{"output":"th1_mt_eff_vs_pt_pi", "x_axis_title":"Gen. #pi^{#pm} p_{T} (GeV)", "y_axis_title":"Match Eff.", "default":{"rebin":"0-200:10"}}'
-  '{"output":"th1_jet_eff_vs_pt", "x_axis_title":"Gen. #tau_{h} p_{T} (GeV)", "y_axis_title":"Jet (p_{T} > 15) Match Eff.", "default":{"rebin":"0-200:10"}}'
-  '{"output":"th1_mt_eff_after_jet_vs_pt", "x_axis_title":"Gen. #tau_{h} p_{T} (GeV)", "y_axis_title":"Match Eff. | Jet Match", "default":{"rebin":"0-200:10"}}'
-  '{"output":"th1_mt_eff_after_jet_pi15_vs_pt", "x_axis_title":"Gen. #tau_{h} p_{T} (GeV)", "y_axis_title":"Match Eff. | Jet Match & p_{T}^{#pi}>15", "default":{"rebin":"0-200:10"}}'
-  '{"output":"th1_mt_eff_after_jet_pi20_vs_pt", "x_axis_title":"Gen. #tau_{h} p_{T} (GeV)", "y_axis_title":"Match Eff. | Jet Match & p_{T}^{#pi}>20", "default":{"rebin":"0-200:10"}}'
+  # '{"output":"th1_mt_eff_vs_pt_pi", "x_axis_title":"Gen. #pi^{#pm} p_{T} (GeV)", "y_axis_title":"Match Eff.", "default":{"rebin":"0-200:10"}}'
+  # '{"output":"th1_jet_eff_vs_pt", "x_axis_title":"Gen. #tau_{h} p_{T} (GeV)", "y_axis_title":"Jet (p_{T} > 15) Match Eff.", "default":{"rebin":"0-200:10"}}'
+  # '{"output":"th1_mt_eff_after_jet_vs_pt", "x_axis_title":"Gen. #tau_{h} p_{T} (GeV)", "y_axis_title":"Match Eff. | Jet Match", "default":{"rebin":"0-200:10"}}'
+  # '{"output":"th1_mt_eff_after_jet_pi15_vs_pt", "x_axis_title":"Gen. #tau_{h} p_{T} (GeV)", "y_axis_title":"Match Eff. | Jet Match & p_{T}^{#pi}>15", "default":{"rebin":"0-200:10"}}'
+  # '{"output":"th1_mt_eff_after_jet_pi20_vs_pt", "x_axis_title":"Gen. #tau_{h} p_{T} (GeV)", "y_axis_title":"Match Eff. | Jet Match & p_{T}^{#pi}>20", "default":{"rebin":"0-200:10"}}'
   )
 
 for i in "${FRAGMENTS[@]}"
@@ -167,3 +167,24 @@ done
 #  --log_y=false --rebin=1 --norm_bins=false \
 #  --title_left="CMS Simulation" \
 #  --outname="compare_th10_pt_resp.pdf"
+
+# root -l -b -q 'macros/plotDMTable.C("output/phys14/Dec7/MC_53X_VBF_HToTauTau_M-125.root", "phys14/th_mode_table",                 "53X_th_mode_table", "VBF H(125 GeV)#rightarrow#tau#tau  #color[2]{53X}")'
+FILE72X="output/phys14/Jan19/MC_72X_VBF_HToTauTau_M-125_PU40bx25.root"
+FILE53X="output/phys14/Jan19/MC_53X_VBF_HToTauTau_M-125.root"
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE72X}'", "phys14/th_pf_match_pt", "th_pf_match_pt_72X", "72X: all modes", "Track p_{T} (GeV)")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE72X}'", "phys14/th_pf_match_eta", "th_pf_match_eta_72X", "72X: all modes", "Track #eta")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE72X}'", "phys14/th0_pf_match_pt", "th0_pf_match_pt_72X", "72X: #pi", "Track p_{T} (GeV)")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE72X}'", "phys14/th0_pf_match_eta", "th0_pf_match_eta_72X", "72X: #pi", "Track #eta")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE72X}'", "phys14/th1_pf_match_pt", "th1_pf_match_pt_72X", "72X: #pi#pi^{0}s", "Track p_{T} (GeV)")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE72X}'", "phys14/th1_pf_match_eta", "th1_pf_match_eta_72X", "72X: #pi#pi^{0}s", "Track #eta")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE72X}'", "phys14/th10_pf_match_pt", "th10_pf_match_pt_72X", "72X: #pi#pi#pi", "Track p_{T} (GeV)")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE72X}'", "phys14/th10_pf_match_eta", "th10_pf_match_eta_72X", "72X: #pi#pi#pi", "Track #eta")'
+
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE53X}'", "phys14/th_pf_match_pt", "th_pf_match_pt_53X", "53X: all modes", "Track p_{T} (GeV)")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE53X}'", "phys14/th_pf_match_eta", "th_pf_match_eta_53X", "53X: all modes", "Track #eta")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE53X}'", "phys14/th0_pf_match_pt", "th0_pf_match_pt_53X", "53X: #pi", "Track p_{T} (GeV)")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE53X}'", "phys14/th0_pf_match_eta", "th0_pf_match_eta_53X", "53X: #pi", "Track #eta")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE53X}'", "phys14/th1_pf_match_pt", "th1_pf_match_pt_53X", "53X: #pi#pi^{0}s", "Track p_{T} (GeV)")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE53X}'", "phys14/th1_pf_match_eta", "th1_pf_match_eta_53X", "53X: #pi#pi^{0}s", "Track #eta")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE53X}'", "phys14/th10_pf_match_pt", "th10_pf_match_pt_53X", "53X: #pi#pi#pi", "Track p_{T} (GeV)")'
+root -l -b -q 'macros/plotPFMatch.C+("'${FILE53X}'", "phys14/th10_pf_match_eta", "th10_pf_match_eta_53X", "53X: #pi#pi#pi", "Track #eta")'

--- a/Analysis/HiggsTauTau/scripts/phys14_run_jobs.sh
+++ b/Analysis/HiggsTauTau/scripts/phys14_run_jobs.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 set -x
 
-PROD=Dec7
+PROD=Jan19
 
 SAMPLES=(
   'MC_53X_VBF_HToTauTau_M-125'
-  'MC_70X_VBF_HToTauTau_M-125_PU20bx25'
-  'MC_70X_VBF_HToTauTau_M-125_PU40bx50'
-  'MC_72X_VBF_HToTauTau_M-125_PU20bx25'
+  # 'MC_70X_VBF_HToTauTau_M-125_PU20bx25'
+  # 'MC_70X_VBF_HToTauTau_M-125_PU40bx50'
+  'MC_72X_VBF_HToTauTau_M-125_PU40bx25'
   # 'MC_70XMINI_VBF_HToTauTau_M-125_PU20bx25'
   # 'MC_72XMINI_VBF_HToTauTau_M-125_PU20bx25'
 )

--- a/Analysis/Objects/Rules.mk
+++ b/Analysis/Objects/Rules.mk
@@ -1,7 +1,7 @@
 SUBDIRS 	:=
 LIB_DEPS 	:=
 LIB_EXTRA :=
-DICTIONARY := interface/Candidate.hh
+DICTIONARY := interface/Candidate.hh interface/PFCandidate.hh
 DICTIONARY += interface/Electron.hh interface/Muon.hh interface/Tau.hh
 DICTIONARY += interface/Photon.hh interface/Jet.hh interface/CaloJet.hh
 DICTIONARY += interface/JPTJet.hh interface/PFJet.hh interface/Met.hh

--- a/docs/Objects.md
+++ b/docs/Objects.md
@@ -35,6 +35,16 @@ Candidate {#objs-candidate}
 **Example usage**
 @snippet python/default_producers_cfi.py Candidate
 
+PFCandidate {#objs-pf-candidate}
+===========================
+ - **Definition**: ic::PFCandidate
+ - **CMSSW Producers**: ICPFProducer, ICPFFromPackedProducer
+ - **Producer Input**: Either a collection compatible with an `edm::View<reco::PFCandidate>` or an `edm::View<pat::PackedCandidate>` (the latter only available in CMSSW_7_X_Y series releases)
+ - **Producer Output**: `std::vector<ic::PFCandidate>`
+
+**Example usage**
+@snippet python/default_producers_cfi.py PFCandidate
+
 CompositeCandidate {#objs-composite}
 =========
  - **Definition**: ic::CompositeCandidate

--- a/interface/LinkDef.h
+++ b/interface/LinkDef.h
@@ -15,6 +15,9 @@
 #pragma link C++ class ic::Candidate+;
 #pragma link C++ class std::vector<ic::Candidate>+;
 
+#pragma link C++ class ic::PFCandidate+;
+#pragma link C++ class std::vector<ic::PFCandidate>+;
+
 #pragma link C++ class ic::Electron+;
 #pragma link C++ class std::vector<ic::Electron>+;
 

--- a/interface/PFCandidate.hh
+++ b/interface/PFCandidate.hh
@@ -8,6 +8,8 @@
 
 namespace ic {
 
+enum class PFType { X, h, e, mu, gamma, h0, h_HF, egamma_HF };
+
 /**
  * @brief Stores the basic properties of PFCandidates (and PackedCandidates for
  * CMSSW 7_X_Y)
@@ -35,6 +37,32 @@ class PFCandidate : public Candidate {
   /// A vector to refer to the constituent gsf track ic::Track::id() values
   inline std::vector<std::size_t> const& constituent_gsf_tracks() const {
     return constituent_gsf_tracks_;
+  }
+
+  /// Converts the pdgid into the enumerated PFType
+  /// Follows the convention of:
+  /// DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+  inline PFType type() const {
+    switch (std::abs(pdgid())) {
+      case 211:
+        return PFType::h;
+      case 11:
+        return PFType::e;
+      case 13:
+        return PFType::mu;
+      case 22:
+        return PFType::gamma;
+      case 130:
+        return PFType::h0;
+      case 1:
+        return PFType::h_HF;
+      case 2:
+        return PFType::egamma_HF;
+      case 0:
+        return PFType::X;
+      default:
+        return PFType::X;
+    }
   }
   /**@}*/
 

--- a/interface/PFCandidate.hh
+++ b/interface/PFCandidate.hh
@@ -1,0 +1,73 @@
+#ifndef ICHiggsTauTau_PFCandidate_hh
+#define ICHiggsTauTau_PFCandidate_hh
+#include <vector>
+#include "Math/Point3D.h"
+#include "Math/Point3Dfwd.h"
+#include "../interface/Candidate.hh"
+#include "Rtypes.h"
+
+namespace ic {
+
+/**
+ * @brief Stores the basic properties of PFCandidates (and PackedCandidates for
+ * CMSSW 7_X_Y)
+ */
+class PFCandidate : public Candidate {
+ private:
+  // typedef ROOT::Math::XYZPoint Point;
+
+ public:
+  PFCandidate();
+  virtual ~PFCandidate();
+  virtual void Print() const;
+
+  /// @name Properties
+  /**@{*/
+
+  /// PDG number to identify the PF candidate type
+  inline int pdgid() const { return pdgid_; }
+
+  /// A vector to refer to the constituent track ic::Track::id() values
+  inline std::vector<std::size_t> const& constituent_tracks() const {
+    return constituent_tracks_;
+  }
+
+  /// A vector to refer to the constituent gsf track ic::Track::id() values
+  inline std::vector<std::size_t> const& constituent_gsf_tracks() const {
+    return constituent_gsf_tracks_;
+  }
+  /**@}*/
+
+  /// @name Setters
+  /**@{*/
+  /// @copybrief pdgid()
+  inline void set_pdgid(int const& pdgid) { pdgid_ = pdgid; }
+
+  /// @copybrief constituent_tracks()
+  inline void set_constituent_tracks(
+      std::vector<std::size_t> const& constituent_tracks) {
+    constituent_tracks_ = constituent_tracks;
+  }
+
+  inline void set_constituent_gsf_tracks(
+      std::vector<std::size_t> const& constituent_gsf_tracks) {
+    constituent_gsf_tracks_ = constituent_gsf_tracks;
+  }
+  /**@}*/
+
+ private:
+  int pdgid_;
+  std::vector<std::size_t> constituent_tracks_;
+  std::vector<std::size_t> constituent_gsf_tracks_;
+
+
+ #ifndef SKIP_CINT_DICT
+ public:
+  ClassDef(PFCandidate, 2);
+ #endif
+};
+
+typedef std::vector<ic::PFCandidate> PFCandidateCollection;
+}
+/** \example plugins/ICPFCandidateProducer.cc */
+#endif

--- a/interface/PFCandidate.hh
+++ b/interface/PFCandidate.hh
@@ -8,8 +8,9 @@
 
 namespace ic {
 
-enum class PFType { X, h, e, mu, gamma, h0, h_HF, egamma_HF };
-
+#if !defined(__GCCXML__) && !defined(__CINT__)
+enum PFType { X, h, e, mu, gamma, h0, h_HF, egamma_HF };
+#endif
 /**
  * @brief Stores the basic properties of PFCandidates (and PackedCandidates for
  * CMSSW 7_X_Y)
@@ -39,6 +40,7 @@ class PFCandidate : public Candidate {
     return constituent_gsf_tracks_;
   }
 
+#if !defined(__GCCXML__) && !defined(__CINT__)
   /// Converts the pdgid into the enumerated PFType
   /// Follows the convention of:
   /// DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -64,6 +66,7 @@ class PFCandidate : public Candidate {
         return PFType::X;
     }
   }
+#endif
   /**@}*/
 
   /// @name Setters

--- a/interface/Track.hh
+++ b/interface/Track.hh
@@ -55,6 +55,32 @@ class Track {
   /// The z-coordinate of the PCA
   inline double vz() const { return ref_point_.z(); }
 
+  /// The normalised chi2 of the track fit
+  inline double normalized_chi2() const { return normalized_chi2_; }
+
+  /// Number of tracker hits
+  inline int hits() const { return hits_; }
+
+  /// Number of pixel hits
+  inline int pixel_hits() const { return pixel_hits_; }
+
+  /// Approximate dxy
+  /// Copied from DataFormats/TrackReco/interface/TrackBase.h
+  inline double dxy(Point const& point) {
+    return (-(vx() - point.x()) * momentum().y() +
+            (vy() - point.y()) * momentum().z()) /
+           pt();
+  }
+
+  /// Approximate dz
+  /// Copied from DataFormats/TrackReco/interface/TrackBase.h
+  inline double dz(Point const& point) {
+    return (vz() - point.z()) -
+           ((vx() - point.x()) * momentum().x() +
+            (vy() - point.y()) * momentum().y()) /
+               pt() * momentum().z() / pt();
+  }
+
   /// The track charge
   inline int charge() const { return charge_; }
   /**@}*/
@@ -90,6 +116,21 @@ class Track {
   /// @copybrief vz()
   inline void set_vz(double const& z) { ref_point_.SetZ(z); }
 
+  /// @copybrief normalized_chi2()
+  inline void set_normalized_chi2(double const& normalized_chi2) {
+    normalized_chi2_ = normalized_chi2;
+  }
+
+  /// @copybrief hits()
+  inline void set_hits(int const& hits) {
+    hits_ = hits;
+  }
+
+  /// @copybrief pixel_hits()
+  inline void set_pixel_hits(int const& pixel_hits) {
+    pixel_hits_ = pixel_hits;
+  }
+
   /// @copybrief charge()
   inline void set_charge(int const& charge) { charge_ = charge; }
   /**@}*/
@@ -100,9 +141,14 @@ class Track {
   std::size_t id_;
   int charge_;
 
+  double normalized_chi2_;
+  int hits_;
+  int pixel_hits_;
+
+
  #ifndef SKIP_CINT_DICT
  public:
-  ClassDef(Track, 2);
+  ClassDef(Track, 3);
  #endif
 };
 

--- a/interface/Track.hh
+++ b/interface/Track.hh
@@ -1,5 +1,6 @@
 #ifndef ICHiggsTauTau_Track_hh
 #define ICHiggsTauTau_Track_hh
+#include <stdint.h>
 #include <vector>
 #include "Math/Point3D.h"
 #include "Math/Point3Dfwd.h"

--- a/interface/Track.hh
+++ b/interface/Track.hh
@@ -91,6 +91,13 @@ class Track {
 
   /// The track charge
   inline int charge() const { return charge_; }
+
+  /// The tracking algorithm used to produce this track
+  /// See: DataFormats/TrackReco/interface/TrackBase.h
+  inline int16_t algorithm() const { return algorithm_; }
+
+  /// The track \f$p_{T}\f$ error
+  inline double pt_err() const { return pt_err_; }
   /**@}*/
 
   /// @name Setters
@@ -141,6 +148,14 @@ class Track {
 
   /// @copybrief charge()
   inline void set_charge(int const& charge) { charge_ = charge; }
+
+  /// @copybrief algorithm()
+  inline void set_algorithm(int16_t const& algorithm) {
+    algorithm_ = algorithm;
+  }
+
+  /// @copybrief pt_err()
+  inline void set_pt_err(double const& pt_err) { pt_err_ = pt_err; }
   /**@}*/
 
  private:
@@ -153,10 +168,12 @@ class Track {
   int hits_;
   int pixel_hits_;
 
+  int16_t algorithm_;
+  double pt_err_;
 
  #ifndef SKIP_CINT_DICT
  public:
-  ClassDef(Track, 3);
+  ClassDef(Track, 4);
  #endif
 };
 

--- a/interface/Track.hh
+++ b/interface/Track.hh
@@ -5,6 +5,8 @@
 #include "Math/Point3Dfwd.h"
 #include "Math/Vector3D.h"
 #include "Math/Vector3Dfwd.h"
+#include "Math/Vector4D.h"
+#include "Math/Vector4Dfwd.h"
 #include "Rtypes.h"
 
 namespace ic {
@@ -15,6 +17,7 @@ namespace ic {
 class Track {
  private:
   typedef ROOT::Math::RhoEtaPhiVector ThreeVector;
+  typedef ROOT::Math::PtEtaPhiEVector Vector;
   typedef ROOT::Math::XYZPoint Point;
 
  public:
@@ -26,6 +29,11 @@ class Track {
   /**@{*/
   /// The track momentum
   inline ThreeVector const& momentum() const { return momentum_; }
+
+  /// Create a four-vector using the pion mass hypothesis
+  inline Vector vector() const {
+    return Vector(ROOT::Math::PtEtaPhiMVector(pt(), eta(), phi(), 0.13957018));
+  }
 
   /// The point-of-closest-approach (PCA) of the track to the beamspot
   inline Point const& ref_point() const { return ref_point_; }
@@ -66,7 +74,7 @@ class Track {
 
   /// Approximate dxy
   /// Copied from DataFormats/TrackReco/interface/TrackBase.h
-  inline double dxy(Point const& point) {
+  inline double dxy(Point const& point) const {
     return (-(vx() - point.x()) * momentum().y() +
             (vy() - point.y()) * momentum().z()) /
            pt();
@@ -74,7 +82,7 @@ class Track {
 
   /// Approximate dz
   /// Copied from DataFormats/TrackReco/interface/TrackBase.h
-  inline double dz(Point const& point) {
+  inline double dz(Point const& point) const {
     return (vz() - point.z()) -
            ((vx() - point.x()) * momentum().x() +
             (vy() - point.y()) * momentum().y()) /

--- a/plugins/ICPFCandidateProducer.cc
+++ b/plugins/ICPFCandidateProducer.cc
@@ -1,0 +1,24 @@
+#include "UserCode/ICHiggsTauTau/plugins/ICPFCandidateProducer.hh"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+
+#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+
+
+typedef SingleObjectSelector<reco::PFCandidateCollection,
+                             StringCutObjectSelector<reco::PFCandidate>,
+                             reco::PFCandidateRefVector> PFCandidateRefSelector;
+
+DEFINE_FWK_MODULE(PFCandidateRefSelector);
+
+typedef ICPFCandidateProducer<reco::PFCandidate> ICPFProducer;
+DEFINE_FWK_MODULE(ICPFProducer);
+
+#if CMSSW_MAJOR_VERSION >= 7
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+typedef ICPFCandidateProducer<pat::PackedCandidate> ICPFFromPackedProducer;
+DEFINE_FWK_MODULE(ICPFFromPackedProducer);
+#endif

--- a/plugins/ICPFCandidateProducer.hh
+++ b/plugins/ICPFCandidateProducer.hh
@@ -1,0 +1,183 @@
+#ifndef UserCode_ICHiggsTauTau_ICPFCandidateProducer_h
+#define UserCode_ICHiggsTauTau_ICPFCandidateProducer_h
+
+#include <memory>
+#include <vector>
+#include "boost/functional/hash.hpp"
+#include "boost/format.hpp"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#if CMSSW_MAJOR_VERSION >= 7
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#endif
+// #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "UserCode/ICHiggsTauTau/interface/PFCandidate.hh"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "UserCode/ICHiggsTauTau/interface/city.h"
+#include "UserCode/ICHiggsTauTau/interface/StaticTree.hh"
+#include "UserCode/ICHiggsTauTau/plugins/PrintConfigTools.h"
+
+/**
+ * @brief See documentation [here](\ref objs-pf-candidate)
+ */
+template <class T>
+class ICPFCandidateProducer : public edm::EDProducer {
+ public:
+  explicit ICPFCandidateProducer(const edm::ParameterSet &);
+  ~ICPFCandidateProducer();
+
+ private:
+  virtual void beginJob();
+  virtual void produce(edm::Event &, const edm::EventSetup &);
+  virtual void endJob();
+  void constructSpecific(edm::Handle<edm::View<T> > const& cands_handle,
+                         reco::TrackRefVector* trk_requests,
+                         reco::GsfTrackRefVector* gsf_trk_requests,
+                         edm::Event& event, const edm::EventSetup& setup);
+
+  std::vector<ic::PFCandidate> *cands_;
+  edm::InputTag input_;
+  std::string branch_;
+  bool request_trks_;
+  bool request_gsf_trks_;
+  boost::hash<T const*> cand_hasher_;
+  boost::hash<reco::Track const*> track_hasher_;
+  edm::InputTag track_input_;
+  edm::InputTag gsf_track_input_;
+};
+
+// =============================
+// Template class implementation
+// =============================
+template <class T>
+ICPFCandidateProducer<T>::ICPFCandidateProducer(const edm::ParameterSet& config)
+    : input_(config.getParameter<edm::InputTag>("input")),
+      branch_(config.getParameter<std::string>("branch")),
+      request_trks_(config.getParameter<bool>("requestTracks")),
+      request_gsf_trks_(config.getParameter<bool>("requestGsfTracks")) {
+  cands_ = new std::vector<ic::PFCandidate>();
+
+  if (request_trks_) {
+    produces<reco::TrackRefVector>("requestedTracks");
+  }
+
+  if (request_gsf_trks_) {
+    produces<reco::GsfTrackRefVector>("requestedGsfTracks");
+  }
+
+  PrintHeaderWithProduces(config, input_, branch_);
+  // PrintOptional(1, do_vertex_ip_, "includeVertexIP");
+  PrintOptional(1, request_trks_, "requestTracks");
+  PrintOptional(1, request_trks_, "requestGsfTracks");
+}
+
+template <class T>
+ICPFCandidateProducer<T>::~ICPFCandidateProducer() { delete cands_; }
+
+// =============
+// Main producer
+// =============
+template <class T>
+void ICPFCandidateProducer<T>::produce(edm::Event& event,
+                                 const edm::EventSetup& setup) {
+  edm::Handle<edm::View<T> > cands_handle;
+  event.getByLabel(input_, cands_handle);
+
+  // edm::Handle<edm::View<reco::Vertex> > vertices_handle;
+  // if (do_vertex_ip_) event.getByLabel(input_vertices_, vertices_handle);
+
+  std::auto_ptr<reco::TrackRefVector> trk_requests(new reco::TrackRefVector());
+  std::auto_ptr<reco::GsfTrackRefVector> gsf_trk_requests(new reco::GsfTrackRefVector());
+
+  cands_->clear();
+  cands_->resize(cands_handle->size(), ic::PFCandidate());
+  for (unsigned i = 0; i < cands_handle->size(); ++i) {
+    T const& src = cands_handle->at(i);
+    ic::PFCandidate& dest = cands_->at(i);
+
+    dest.set_id(cand_hasher_(&src));
+    dest.set_pt(src.pt());
+    dest.set_eta(src.eta());
+    dest.set_phi(src.phi());
+    dest.set_energy(src.energy());
+    dest.set_charge(src.charge());
+    dest.set_pdgid(src.pdgId());
+
+    // dest.set_vx(src.vx());
+    // dest.set_vy(src.vy());
+    // dest.set_vz(src.vz());
+  }
+  constructSpecific(cands_handle, trk_requests.get(), gsf_trk_requests.get(),
+                    event, setup);
+  if (request_trks_) event.put(trk_requests, "requestedTracks");
+  if (request_gsf_trks_) event.put(gsf_trk_requests, "requestedGsfTracks");
+}
+
+// ==================
+// Specific producers
+// ==================
+template <class T>
+void ICPFCandidateProducer<T>::constructSpecific(
+    edm::Handle<edm::View<T> > const& cands_handle,
+    reco::TrackRefVector* trk_requests,
+    reco::GsfTrackRefVector* gsf_trk_requests, edm::Event& event,
+    const edm::EventSetup& setup) {}
+
+template <>
+void ICPFCandidateProducer<reco::PFCandidate>::constructSpecific(
+    edm::Handle<edm::View<reco::PFCandidate> > const& cands_handle,
+    reco::TrackRefVector* trk_requests,
+    reco::GsfTrackRefVector* gsf_trk_requests, edm::Event& event,
+    const edm::EventSetup& setup) {
+  for (unsigned i = 0; i < cands_handle->size(); ++i) {
+    reco::PFCandidate const& src = cands_handle->at(i);
+    ic::PFCandidate& dest = cands_->at(i);
+    if (request_trks_) {
+      std::vector<std::size_t> trk_ids;
+      if (src.trackRef().isNonnull()) {
+        reco::TrackRef const& trk = src.trackRef();
+        trk_requests->push_back(trk);
+        trk_ids.push_back(track_hasher_(&(*trk)));
+      }
+      dest.set_constituent_tracks(trk_ids);
+    }
+
+    if (request_gsf_trks_) {
+      std::vector<std::size_t> trk_ids;
+      if (src.gsfTrackRef().isNonnull()) {
+        reco::GsfTrackRef const& trk = src.gsfTrackRef();
+        gsf_trk_requests->push_back(trk);
+        trk_ids.push_back(track_hasher_(&(*trk)));
+      }
+      dest.set_constituent_gsf_tracks(trk_ids);
+    }
+  }
+}
+
+#if CMSSW_MAJOR_VERSION >= 7
+template <>
+void ICPFCandidateProducer<pat::PackedCandidate>::constructSpecific(
+    edm::Handle<edm::View<pat::PackedCandidate> > const& cands_handle,
+    reco::TrackRefVector* trk_requests,
+    reco::GsfTrackRefVector* gsf_trk_requests, edm::Event& event,
+    const edm::EventSetup& setup) {
+  // To get tracks here we'd actually have to produce a new track collection
+  // first using pseudoTrack(), get it into the event, then produce the refs.
+  // Not trivial I think.
+}
+#endif
+
+template <class T>
+void ICPFCandidateProducer<T>::beginJob() {
+  ic::StaticTree::tree_->Branch(branch_.c_str(), &cands_);
+}
+
+template <class T>
+void ICPFCandidateProducer<T>::endJob() {
+}
+
+#endif

--- a/plugins/ICTrackProducer.cc
+++ b/plugins/ICTrackProducer.cc
@@ -46,6 +46,8 @@ void ICTrackProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     dest.set_normalized_chi2(src.normalizedChi2());
     dest.set_hits(src.hitPattern().numberOfValidHits());
     dest.set_pixel_hits(src.hitPattern().numberOfValidPixelHits());
+    dest.set_algorithm(src.algo());
+    dest.set_pt_err(src.ptError());
   }
 }
 

--- a/plugins/ICTrackProducer.cc
+++ b/plugins/ICTrackProducer.cc
@@ -43,6 +43,9 @@ void ICTrackProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     dest.set_vx(src.vx());
     dest.set_vy(src.vy());
     dest.set_vz(src.vz());
+    dest.set_normalized_chi2(src.normalizedChi2());
+    dest.set_hits(src.hitPattern().numberOfValidHits());
+    dest.set_pixel_hits(src.hitPattern().numberOfValidPixelHits());
   }
 }
 

--- a/plugins/RequestByDeltaR.cc
+++ b/plugins/RequestByDeltaR.cc
@@ -1,0 +1,7 @@
+#include "UserCode/ICHiggsTauTau/plugins/RequestByDeltaR.hh"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+typedef RequestByDeltaR<reco::Track> RequestTracksByDeltaR;
+
+DEFINE_FWK_MODULE(RequestTracksByDeltaR);

--- a/plugins/RequestByDeltaR.hh
+++ b/plugins/RequestByDeltaR.hh
@@ -40,9 +40,9 @@ class RequestByDeltaR : public edm::EDProducer {
 // =============================
 template <class T>
 RequestByDeltaR<T>::RequestByDeltaR(const edm::ParameterSet& config)
-    : input_(config.getParameter<edm::InputTag>("input")),
+    : input_(config.getParameter<edm::InputTag>("src")),
       reference_(config.getParameter<edm::InputTag>("reference")),
-      dr_(config.getParameter<bool>("deltaR")) {
+      dr_(config.getParameter<double>("deltaR")) {
   produces<RefVectorVec>();
   PrintHeaderWithProduces(config, input_, "");
   std::cout << boost::format("%-15s : %-60s\n") % "Reference" %
@@ -68,7 +68,7 @@ void RequestByDeltaR<T>::produce(edm::Event& event,
   std::auto_ptr<RefVectorVec> product(new RefVectorVec());
 
   for (unsigned i = 0; i < in_handle->size(); ++i) {
-    for (unsigned j = 0; i < ref_handle->size(); ++j) {
+    for (unsigned j = 0; j < ref_handle->size(); ++j) {
       double dr = reco::deltaR(in_handle->at(i), ref_handle->at(j));
       if (dr <= dr_) {
         product->push_back(in_handle->refAt(i).template castTo<RefVec>());

--- a/plugins/RequestByDeltaR.hh
+++ b/plugins/RequestByDeltaR.hh
@@ -1,0 +1,88 @@
+#ifndef UserCode_ICHiggsTauTau_RequestByDeltaR_h
+#define UserCode_ICHiggsTauTau_RequestByDeltaR_h
+
+#include <memory>
+#include <vector>
+#include "boost/functional/hash.hpp"
+#include "boost/format.hpp"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "UserCode/ICHiggsTauTau/interface/city.h"
+#include "UserCode/ICHiggsTauTau/interface/StaticTree.hh"
+#include "UserCode/ICHiggsTauTau/plugins/PrintConfigTools.h"
+
+template <class T>
+class RequestByDeltaR : public edm::EDProducer {
+ public:
+  explicit RequestByDeltaR(const edm::ParameterSet &);
+  ~RequestByDeltaR();
+
+ private:
+  virtual void beginJob();
+  virtual void produce(edm::Event &, const edm::EventSetup &);
+  virtual void endJob();
+
+  edm::InputTag input_;
+  edm::InputTag reference_;
+  double dr_;
+
+  typedef std::vector<T> Vec;
+  typedef edm::RefVector<Vec> RefVectorVec;
+  typedef edm::Ref<Vec> RefVec;
+};
+
+// =============================
+// Template class implementation
+// =============================
+template <class T>
+RequestByDeltaR<T>::RequestByDeltaR(const edm::ParameterSet& config)
+    : input_(config.getParameter<edm::InputTag>("input")),
+      reference_(config.getParameter<edm::InputTag>("reference")),
+      dr_(config.getParameter<bool>("deltaR")) {
+  produces<RefVectorVec>();
+  PrintHeaderWithProduces(config, input_, "");
+  std::cout << boost::format("%-15s : %-60s\n") % "Reference" %
+                   reference_.encode();
+  std::cout << boost::format("%-15s : %-60s\n") % "DeltaR" % dr_;
+}
+
+template <class T>
+RequestByDeltaR<T>::~RequestByDeltaR() { }
+
+// =============
+// Main producer
+// =============
+template <class T>
+void RequestByDeltaR<T>::produce(edm::Event& event,
+                                 const edm::EventSetup& setup) {
+
+  edm::Handle<edm::View<reco::Candidate> > ref_handle;
+  event.getByLabel(reference_, ref_handle);
+  edm::Handle<edm::View<T> > in_handle;
+  event.getByLabel(input_, in_handle);
+
+  std::auto_ptr<RefVectorVec> product(new RefVectorVec());
+
+  for (unsigned i = 0; i < in_handle->size(); ++i) {
+    for (unsigned j = 0; i < ref_handle->size(); ++j) {
+      double dr = reco::deltaR(in_handle->at(i), ref_handle->at(j));
+      if (dr <= dr_) {
+        product->push_back(in_handle->refAt(i).template castTo<RefVec>());
+        break;
+      }
+    }
+  }
+  event.put(product);
+}
+
+template <class T>
+void RequestByDeltaR<T>::beginJob() {}
+
+template <class T>
+void RequestByDeltaR<T>::endJob() {}
+
+#endif

--- a/python/default_producers_cfi.py
+++ b/python/default_producers_cfi.py
@@ -7,6 +7,13 @@ icCandidateProducer = cms.EDProducer('ICCandidateProducer',
 )
 ## [Candidate]
 
+## [PFCandidate]
+icPFProducer = cms.EDProducer('ICPFProducer',
+  branch  = cms.string("pfCandidates"),
+  input   = cms.InputTag("particleFlow", "", "RECO")
+)
+## [PFCandidate]
+
 ## [Electron]
 icElectronProducer = cms.EDProducer('ICElectronProducer',
     branch                    = cms.string("electrons"),

--- a/src/PFCandidate.cc
+++ b/src/PFCandidate.cc
@@ -1,0 +1,13 @@
+#include "../interface/PFCandidate.hh"
+#include "boost/format.hpp"
+namespace ic {
+// Constructors/Destructors
+PFCandidate::PFCandidate() : pdgid_(0) {}
+
+PFCandidate::~PFCandidate() {}
+
+void PFCandidate::Print() const {
+  Candidate::Print();
+  std::cout << "[pdgid] = " << this->pdgid() << "\n";
+}
+}

--- a/src/Track.cc
+++ b/src/Track.cc
@@ -2,7 +2,8 @@
 
 namespace ic {
 // Constructors/Destructors
-Track::Track() : id_(0), charge_(0) {}
+Track::Track()
+    : id_(0), charge_(0), normalized_chi2_(0.), hits_(0), pixel_hits_(0) {}
 
 Track::~Track() {}
 

--- a/src/classes.h
+++ b/src/classes.h
@@ -3,6 +3,7 @@
 #include <utility>
 #include <string>
 #include "UserCode/ICHiggsTauTau/interface/Candidate.hh"
+#include "UserCode/ICHiggsTauTau/interface/PFCandidate.hh"
 #include "UserCode/ICHiggsTauTau/interface/GenParticle.hh"
 #include "UserCode/ICHiggsTauTau/interface/Jet.hh"
 #include "UserCode/ICHiggsTauTau/interface/CaloJet.hh"
@@ -27,6 +28,10 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
 namespace { struct dictionary {
   ic::Candidate dummy1;
@@ -80,6 +85,10 @@ namespace { struct dictionary {
   std::vector<ic::SecondaryVertex> dummy50;
   edm::Wrapper<reco::SecondaryVertexTagInfoRefVector> dummy51;
   edm::Wrapper<reco::VertexRefVector> dummy52;
+  ic::PFCandidate dummy53;
+  std::vector<ic::PFCandidate> dummy54;
+  edm::Wrapper<reco::GsfTrackRefVector> dummy55;
+  edm::Wrapper<reco::PFCandidateRefVector> dummy56;
 };
 }
 

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -1,6 +1,8 @@
 <lcgdict>
   <class name="ic::Candidate"/>
   <class name="std::vector<ic::Candidate>"/>
+  <class name="ic::PFCandidate"/>
+  <class name="std::vector<ic::PFCandidate>"/>
   <class name="ic::GenParticle"/>
   <class name="std::vector<ic::GenParticle>"/> 
   <class name="ic::Jet"/>
@@ -50,4 +52,6 @@
   <class name="mithep::TH2DAsymErr"/>
   <class name="edm::Wrapper<reco::SecondaryVertexTagInfoRefVector>"/>
   <class name="edm::Wrapper<reco::VertexRefVector>"/>
+  <class name="edm::Wrapper<reco::GsfTrackRefVector>"/>
+  <class name="edm::Wrapper<reco::PFCandidateRefVector>"/>
 </lcgdict>

--- a/test/higgstautau_new_cfg.py
+++ b/test/higgstautau_new_cfg.py
@@ -310,8 +310,13 @@ process.selectedTracks = cms.EDFilter("TrackRefSelector",
   cut = cms.string("pt > 5")
 )
 
-process.requestTracksByDeltaRToTaus = cms.EDProducer("RequestTracksByDeltaR",
+process.selectedTauTracks = cms.EDFilter("TrackRefSelector",
   src = cms.InputTag("generalTracks"),
+  cut = cms.string("pt > 0.5")
+)
+
+process.requestTracksByDeltaRToTaus = cms.EDProducer("RequestTracksByDeltaR",
+  src = cms.InputTag("selectedTauTracks"),
   reference = cms.InputTag("selectedPFTaus"),
   deltaR = cms.double(0.5)
   )
@@ -320,7 +325,7 @@ process.requestTracksByDeltaRToTaus = cms.EDProducer("RequestTracksByDeltaR",
 # - all tracks with pT > 5 GeV
 # - tracks referenced by the PF candidates we store
 # - tracks referenced by the taus we store
-# - all tracks with DR < 0.5 pf the selected PF taus
+# - all tracks with DR < 0.5 pf the selected PF taus with pT > 0.5 GeV
 process.icMergedTracks = cms.EDProducer('ICTrackMerger',
   merge = cms.VInputTag(
     cms.InputTag("selectedTracks"),
@@ -344,6 +349,7 @@ process.icTrackSequence = cms.Sequence()
 if isPhys14:
   process.icTrackSequence += cms.Sequence(
     process.selectedTracks+
+    process.selectedTauTracks+
     process.requestTracksByDeltaRToTaus+
     process.icMergedTracks+
     process.icTrackProducer+

--- a/test/higgstautau_new_cfg.py
+++ b/test/higgstautau_new_cfg.py
@@ -770,6 +770,18 @@ process.icPFJetProducer = producers.icPFJetProducer.clone(
       requestTracks         = cms.bool(False)
     )
 )
+
+
+process.selectedPFJetsAK4 = cms.EDFilter("PFJetRefSelector",
+    src = cms.InputTag("ak4PFJets"),
+    cut = cms.string("pt > 15")
+    )
+
+process.icPFJetProducerAK4 = producers.icPFJetProducer.clone(
+    branch                    = cms.string("ak4PFJets"),
+    input                     = cms.InputTag("selectedPFJetsAK4")
+)
+
 if release in ['70XMINIAOD', '72XMINIAOD']:
   process.icPFJetProducer.destConfig.includePileupID = cms.bool(False)
   process.icPFJetProducer.destConfig.includeTrackBasedVars = cms.bool(False)
@@ -799,6 +811,11 @@ if release in ['72X', '72XMINIAOD']:
       process.icPFJetFlavourCalculator+
       process.icPFJetProducer
       )
+  if isPhys14:
+    process.icPFJetSequence += cms.Sequence(
+        process.selectedPFJetsAK4+
+        process.icPFJetProducerAK4
+        )
 else:
   process.icPFJetSequence += cms.Sequence(
       process.jetPartons+
@@ -990,7 +1007,7 @@ process.ak5GenJetsNoNuBSM  =  process.ak5GenJets.clone()
 
 process.selectedGenJets = cms.EDFilter("GenJetRefSelector",
   src = cms.InputTag("ak5GenJetsNoNuBSM"),
-  cut = cms.string("pt > 15.0")
+  cut = cms.string("pt > 10.0")
 )
 
 process.icGenJetProducer = producers.icGenJetProducer.clone(
@@ -1015,6 +1032,25 @@ if not isData:
       process.selectedGenJets+
       process.icGenJetProducer
     )
+
+if release in ['72X'] and isPhys14:
+  process.load("RecoJets.JetProducers.ak4GenJets_cfi")
+  process.ak4GenJetsNoNuBSM  =  process.ak4GenJets.clone()
+  process.selectedGenJetsAK4 = cms.EDFilter("GenJetRefSelector",
+    src = cms.InputTag("ak4GenJetsNoNuBSM"),
+    cut = cms.string("pt > 10.0")
+  )
+  process.icGenJetProducerAK4 = producers.icGenJetProducer.clone(
+    branch  = cms.string("ak4GenJets"),
+    input   = cms.InputTag("selectedGenJetsAK4"),
+    inputGenParticles = cms.InputTag("genParticles"),
+    requestGenParticles = cms.bool(False)
+  )
+  process.icGenSequence += (
+      process.ak4GenJetsNoNuBSM+
+      process.selectedGenJetsAK4+
+      process.icGenJetProducerAK4
+  )
 
 ################################################################
 # Embedding


### PR DESCRIPTION
 - Add new PFCandidate class and corresponding CMSSW producer
 	* Producer is templated: one version for classic reco::PFCandidate, and one for the new MINIAOD pat::PackedCandidate
 	* Currently only very basic info is stored - expect more to be added later
 	* The IDs of consituent reco::Tracks or reco::GsfTracks can be stored
 - Added a few extra variables to ic::Track class: normalizedChi2 of the track fit, total number of hits, and total number of pixel hits. These are needed for applying quality criteria used in tau reconstruction.