### PR TITLE
Adapt ICTriggerPathProducer and ICTriggerObjectProducer to run on miniAOD input

### DIFF
--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -14,6 +14,7 @@
   <use name="JetMETCorrections/METPUSubtraction"/>
   <use name="JetMETCorrections/Objects"/>
   <use name="PhysicsTools/HepMCCandAlgos"/>
+  <use name="HLTrigger/HLTcore"/>
   <use name="clhep"/>
   <flags EDM_PLUGIN="1"/>
   <flags CXXFLAGS="`printenv CMSSW_VERSION | sed 's/CMSSW_\([0-9]*\)_\([0-9]*\)_[0-9]*.*/-DCMSSW_MAJOR_VERSION=\1 -DCMSSW_MINOR_VERSION=\2/'`"/>

--- a/plugins/ICTriggerObjectProducer.cc
+++ b/plugins/ICTriggerObjectProducer.cc
@@ -9,8 +9,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "PhysicsTools/PatUtils/interface/TriggerHelper.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "UserCode/ICHiggsTauTau/interface/TriggerObject.hh"
 #include "UserCode/ICHiggsTauTau/interface/StaticTree.hh"
 #include "UserCode/ICHiggsTauTau/interface/city.h"
@@ -19,67 +23,157 @@
 ICTriggerObjectProducer::ICTriggerObjectProducer(
     const edm::ParameterSet& config)
     : input_(config.getParameter<edm::InputTag>("input")),
+      input_trigres_(config.getParameter<edm::InputTag>("inputTriggerResults")),
       branch_(config.getParameter<std::string>("branch")),
       hlt_path_(config.getParameter<std::string>("hltPath")),
-      store_only_if_fired_(config.getParameter<bool>("storeOnlyIfFired")) {
+      store_only_if_fired_(config.getParameter<bool>("storeOnlyIfFired")),
+      input_is_standalone_(config.getParameter<bool>("inputIsStandAlone")) {
   objects_ = new std::vector<ic::TriggerObject>();
   PrintHeaderWithProduces(config, input_, branch_);
   std::cout << boost::format("%-15s : %-60s\n") % "Path" % hlt_path_;
   PrintOptional(1, store_only_if_fired_, "storeOnlyIfFired");
+  PrintOptional(1, input_is_standalone_, "inputIsStandAlone");
 }
 
 ICTriggerObjectProducer::~ICTriggerObjectProducer() { delete objects_; }
 
 void ICTriggerObjectProducer::produce(edm::Event& event,
                                       const edm::EventSetup& setup) {
-  edm::Handle<pat::TriggerEvent> trig_handle;
-  event.getByLabel(input_, trig_handle);
-
   objects_->clear();
 
-  // Get a vector of all HLT paths
-  std::vector<pat::TriggerPath> const* paths = trig_handle->paths();
+  if (!input_is_standalone_) {
+    edm::Handle<pat::TriggerEvent> trig_handle;
+    event.getByLabel(input_, trig_handle);
 
-  // Find the full label of the chosen HLT path (i.e. with the version number)
-  bool fired = true;
-  std::string full_name;
-  for (unsigned i = 0; i < paths->size(); ++i) {
-    std::string const& name = paths->at(i).name();
-    if (name.find(hlt_path_) != name.npos) {
-      full_name = name;
-      if (store_only_if_fired_ && !(paths->at(i).wasAccept())) fired = false;
-      break;  // Stop loop after we find the first match
+
+    // Get a vector of all HLT paths
+    std::vector<pat::TriggerPath> const* paths = trig_handle->paths();
+
+    // Find the full label of the chosen HLT path (i.e. with the version number)
+    bool fired = true;
+    std::string full_name;
+    for (unsigned i = 0; i < paths->size(); ++i) {
+      std::string const& name = paths->at(i).name();
+      if (name.find(hlt_path_) != name.npos) {
+        full_name = name;
+        if (store_only_if_fired_ && !(paths->at(i).wasAccept())) fired = false;
+        break;  // Stop loop after we find the first match
+      }
     }
-  }
-  if (!fired) return;
+    if (!fired) return;
 
-  // Get a vector of the objects used in the chosen path
-  pat::TriggerObjectRefVector objects =
-      trig_handle->pathObjects(full_name, false);
-  objects_->resize(objects.size(), ic::TriggerObject());
-  for (unsigned i = 0; i < objects.size(); ++i) {
-    pat::TriggerObject const& src = *(objects.at(i));
-    ic::TriggerObject & dest = objects_->at(i);
-    dest.set_pt(src.pt());
-    dest.set_eta(src.eta());
-    dest.set_phi(src.phi());
-    dest.set_energy(src.energy());
-    dest.set_charge(0);
-    dest.set_id(0);
-    std::vector<std::size_t> filter_labels;
+    // Get a vector of the objects used in the chosen path
+    pat::TriggerObjectRefVector objects =
+        trig_handle->pathObjects(full_name, false);
+    objects_->resize(objects.size(), ic::TriggerObject());
+    for (unsigned i = 0; i < objects.size(); ++i) {
+      pat::TriggerObject const& src = *(objects.at(i));
+      ic::TriggerObject & dest = objects_->at(i);
+      dest.set_pt(src.pt());
+      dest.set_eta(src.eta());
+      dest.set_phi(src.phi());
+      dest.set_energy(src.energy());
+      dest.set_charge(0);
+      dest.set_id(0);
+      std::vector<std::size_t> filter_labels;
 
-    // Get the filters this object was used in
-    pat::TriggerFilterRefVector filters =
-        trig_handle->objectFilters((objects)[i], false);
-    for (unsigned k = 0; k < filters.size(); ++k) {
-      // Only store the filter label if the filter was used in the chosen path
-      if (!trig_handle->filterInPath(filters[k], full_name, false)) continue;
-      filter_labels.push_back(CityHash64(filters[k]->label()));
-      observed_filters_[filters[k]->label()] = CityHash64(filters[k]->label());
+      // Get the filters this object was used in
+      pat::TriggerFilterRefVector filters =
+          trig_handle->objectFilters((objects)[i], false);
+      for (unsigned k = 0; k < filters.size(); ++k) {
+        // Only store the filter label if the filter was used in the chosen path
+        if (!trig_handle->filterInPath(filters[k], full_name, false)) continue;
+        filter_labels.push_back(CityHash64(filters[k]->label()));
+        observed_filters_[filters[k]->label()] = CityHash64(filters[k]->label());
+      }
+      dest.set_filters(filter_labels);
     }
-    dest.set_filters(filter_labels);
+  } else {  // i.e. MiniAOD
+    // We need to figure out the full HLT path name (typically hlt_path_ doesn't
+    // contain the version number at the end). We don't have access to the full
+    // pat::TriggerEvent here, but we can get the same information from the
+    // edm::TriggerResults instead.
+    // This code was inspired by the example here:
+    //  https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD#Trigger
+    edm::Handle<edm::TriggerResults> trigres_handle;
+    event.getByLabel(input_trigres_, trigres_handle);
+    edm::TriggerNames const& names = event.triggerNames(*trigres_handle);
+
+    bool fired = true;
+    std::string full_name;
+
+    for (unsigned int i = 0, n = trigres_handle->size(); i < n; ++i) {
+      std::string const& name = names.triggerName(i);
+      // std::cout << i << "\t" << name << "\n";
+      if (name.find(hlt_path_) != name.npos) {
+        full_name = name;
+        if (store_only_if_fired_ && !(trigres_handle->accept(i))) fired = false;
+        break;  // Stop loop after we find the first match
+      }
+    }
+    if (!fired) return;
+
+    // Have to use the HLTConfigProvider to get the list of object-producing
+    // filter modules that were run in this path
+    std::set<std::string> path_filters;
+    std::vector<std::string> const& filt_vec =
+        hlt_config_.saveTagsModules(full_name);
+    for (unsigned i = 0; i < filt_vec.size(); ++i)
+      path_filters.insert(filt_vec[i]);
+
+    edm::Handle<pat::TriggerObjectStandAloneCollection> trigobj_handle;
+    event.getByLabel(input_, trigobj_handle);
+    for (unsigned i = 0; i < trigobj_handle->size(); ++i) {
+      pat::TriggerObjectStandAlone src = trigobj_handle->at(i);
+      src.unpackPathNames(names);
+      std::vector<std::string> const& pathnames = src.pathNames();
+      bool obj_in_path = false;
+      for (unsigned j = 0; j < pathnames.size(); ++j) {
+        if (full_name == pathnames[j]) {
+          obj_in_path = true;
+          break;
+        }
+      }
+      if (!obj_in_path) continue;
+
+      // Ok, so this object was used in the path - now we can add it to the
+      // output collection
+      objects_->push_back(ic::TriggerObject());
+      ic::TriggerObject & dest = objects_->back();
+      dest.set_pt(src.pt());
+      dest.set_eta(src.eta());
+      dest.set_phi(src.phi());
+      dest.set_energy(src.energy());
+      dest.set_charge(0);
+      dest.set_id(0);
+      // Get the filters this object was used in
+      std::vector<std::string> const& filters = src.filterLabels();
+      std::vector<std::size_t> filter_labels;
+      for (unsigned k = 0; k < filters.size(); ++k) {
+        // Using the info we got from the HLTConfigProvider we can check if this
+        // filter module was actually used in the path we are interested in
+        if (!path_filters.count(filters[k])) continue;
+        filter_labels.push_back(CityHash64(filters[k]));
+        observed_filters_[filters[k]] = CityHash64(filters[k]);
+      }
+      dest.set_filters(filter_labels);
+    }
   }
 }
+
+void ICTriggerObjectProducer::beginRun(edm::Run const& run,
+                                       edm::EventSetup const& es) {
+  if (input_is_standalone_) {
+    std::string proc =
+        input_trigres_.process() != "" ? input_trigres_.process() : "HLT";
+    bool changed = true;
+    bool res = hlt_config_.init(run, es, proc, changed);
+    if (!res)
+      throw std::runtime_error(
+          "HLTConfigProvider did not initialise correctly");
+  }
+}
+
 
 void ICTriggerObjectProducer::beginJob() {
   ic::StaticTree::tree_->Branch(branch_.c_str(), &objects_);

--- a/plugins/ICTriggerObjectProducer.cc
+++ b/plugins/ICTriggerObjectProducer.cc
@@ -125,7 +125,11 @@ void ICTriggerObjectProducer::produce(edm::Event& event,
     event.getByLabel(input_, trigobj_handle);
     for (unsigned i = 0; i < trigobj_handle->size(); ++i) {
       pat::TriggerObjectStandAlone src = trigobj_handle->at(i);
+#if CMSSW_MAJOR_VERSION >= 7
+      // In MiniAOD the path names have to be unpacked, but this method
+      // was only introduced in CMSSW_7_0_5
       src.unpackPathNames(names);
+#endif
       std::vector<std::string> const& pathnames = src.pathNames();
       bool obj_in_path = false;
       for (unsigned j = 0; j < pathnames.size(); ++j) {

--- a/plugins/ICTriggerObjectProducer.hh
+++ b/plugins/ICTriggerObjectProducer.hh
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
 #include "UserCode/ICHiggsTauTau/interface/TriggerObject.hh"
 
@@ -24,14 +25,18 @@ class ICTriggerObjectProducer : public edm::EDProducer {
  private:
   virtual void beginJob();
   virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void beginRun(edm::Run const& run, edm::EventSetup const& es);
   virtual void endJob();
 
   std::vector<ic::TriggerObject>* objects_;
   edm::InputTag input_;
+  edm::InputTag input_trigres_;
   std::string branch_;
   std::string hlt_path_;
   bool store_only_if_fired_;
+  bool input_is_standalone_;
   std::map<std::string, std::size_t> observed_filters_;
+  HLTConfigProvider hlt_config_;
 };
 
 #endif

--- a/plugins/ICTriggerPathProducer.cc
+++ b/plugins/ICTriggerPathProducer.cc
@@ -11,7 +11,9 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
+#include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 #include "PhysicsTools/PatUtils/interface/TriggerHelper.h"
 #include "UserCode/ICHiggsTauTau/interface/TriggerPath.hh"
 #include "UserCode/ICHiggsTauTau/interface/StaticTree.hh"
@@ -23,48 +25,77 @@ ICTriggerPathProducer::ICTriggerPathProducer(const edm::ParameterSet& config)
       branch_(config.getParameter<std::string>("branch")),
       include_if_fired_(config.getParameter<bool>("includeAcceptedOnly")),
       save_strings_(config.getParameter<bool>("saveStrings")),
-      split_version_(config.getParameter<bool>("splitVersion")) {
+      split_version_(config.getParameter<bool>("splitVersion")),
+      input_is_standalone_(config.getParameter<bool>("inputIsStandAlone")),
+      input_prescales_(config.getParameter<edm::InputTag>("inputPrescales")) {
   paths_ = new std::vector<ic::TriggerPath>();
   PrintHeaderWithProduces(config, input_, branch_);
   PrintOptional(1, include_if_fired_, "includeAcceptedOnly");
   PrintOptional(1, save_strings_, "saveStrings");
   PrintOptional(1, split_version_, "splitVersion");
+  PrintOptional(1, input_is_standalone_, "inputIsStandAlone");
 }
 
 ICTriggerPathProducer::~ICTriggerPathProducer() { delete paths_; }
 
 void ICTriggerPathProducer::produce(edm::Event& event,
                                     const edm::EventSetup& setup) {
-  edm::Handle<pat::TriggerEvent> trig_handle;
-  event.getByLabel(input_, trig_handle);
-  std::vector<pat::TriggerPath> const* paths = trig_handle->paths();
   paths_->clear();
-  paths_->reserve(paths->size());
-  for (unsigned i = 0; i < paths->size(); ++i) {
-    pat::TriggerPath const& src = paths->at(i);
-    if (!src.wasAccept() && include_if_fired_) continue;
-    paths_->push_back(ic::TriggerPath());
-    ic::TriggerPath & dest = paths_->back();
-    dest.set_accept(src.wasAccept());
-    dest.set_prescale(src.prescale());
-    std::string name = src.name();
-    if (split_version_) {
-      std::size_t v_pos = name.find_last_of('v');
-      if (v_pos != std::string::npos) {
-        std::string post_v = name.substr(v_pos+1);
-        std::string pre_v = name.substr(0, v_pos+1);
-        try {
-          unsigned v = boost::lexical_cast<unsigned>(post_v);
-          name = pre_v;
-          dest.set_version(v);
-        }
-        catch(boost::bad_lexical_cast const& e) {
-        }
+
+  if (!input_is_standalone_) {
+    edm::Handle<pat::TriggerEvent> trig_handle;
+    event.getByLabel(input_, trig_handle);
+    std::vector<pat::TriggerPath> const* paths = trig_handle->paths();
+    paths_->reserve(paths->size());
+    for (unsigned i = 0; i < paths->size(); ++i) {
+      pat::TriggerPath const& src = paths->at(i);
+      if (!src.wasAccept() && include_if_fired_) continue;
+      paths_->push_back(ic::TriggerPath());
+      ic::TriggerPath & dest = paths_->back();
+      dest.set_accept(src.wasAccept());
+      dest.set_prescale(src.prescale());
+      std::string name = src.name();
+      SetNameInfo(name, &dest);
+    }
+  } else {  // i.e. MiniAOD
+    edm::Handle<edm::TriggerResults> trigres_handle;
+    event.getByLabel(input_, trigres_handle);
+
+    edm::Handle<pat::PackedTriggerPrescales> prescales_handle;
+    event.getByLabel(input_prescales_, prescales_handle);
+
+    edm::TriggerNames const& names = event.triggerNames(*trigres_handle);
+    paths_->reserve(trigres_handle->size());
+    for (unsigned int i = 0, n = trigres_handle->size(); i < n; ++i) {
+      if (!trigres_handle->accept(i) && include_if_fired_) continue;
+      paths_->push_back(ic::TriggerPath());
+      ic::TriggerPath & dest = paths_->back();
+      dest.set_accept(trigres_handle->accept(i));
+      dest.set_prescale(prescales_handle->getPrescaleForIndex(i));
+      std::string name = names.triggerName(i);
+      SetNameInfo(name, &dest);
+    }
+  }
+}
+
+void ICTriggerPathProducer::SetNameInfo(std::string name,
+                                        ic::TriggerPath* path) {
+  if (split_version_) {
+    std::size_t v_pos = name.find_last_of('v');
+    if (v_pos != std::string::npos) {
+      std::string post_v = name.substr(v_pos+1);
+      std::string pre_v = name.substr(0, v_pos+1);
+      try {
+        unsigned v = boost::lexical_cast<unsigned>(post_v);
+        name = pre_v;
+        path->set_version(v);
+      }
+      catch(boost::bad_lexical_cast const& e) {
       }
     }
-    if (save_strings_) dest.set_name(name);
-    dest.set_id(CityHash64(name));
   }
+  if (save_strings_) path->set_name(name);
+  path->set_id(CityHash64(name));
 }
 
 void ICTriggerPathProducer::beginJob() {

--- a/plugins/ICTriggerPathProducer.hh
+++ b/plugins/ICTriggerPathProducer.hh
@@ -22,12 +22,17 @@ class ICTriggerPathProducer : public edm::EDProducer {
   virtual void produce(edm::Event &, const edm::EventSetup &);
   virtual void endJob();
 
+  void SetNameInfo(std::string name, ic::TriggerPath *path);
+
   std::vector<ic::TriggerPath> *paths_;
   edm::InputTag input_;
   std::string branch_;
   bool include_if_fired_;
   bool save_strings_;
   bool split_version_;
+  bool input_is_standalone_;
+  edm::InputTag input_prescales_;
+
 };
 
 #endif

--- a/python/default_producers_cfi.py
+++ b/python/default_producers_cfi.py
@@ -360,7 +360,9 @@ icTriggerPathProducer = cms.EDProducer('ICTriggerPathProducer',
   input   = cms.InputTag("patTriggerEvent"),
   includeAcceptedOnly = cms.bool(True),
   saveStrings = cms.bool(True),
-  splitVersion = cms.bool(False)
+  splitVersion = cms.bool(False),
+  inputIsStandAlone = cms.bool(False),
+  inputPrescales = cms.InputTag("patTrigger", "", "PAT") # only used when inputIsStandAlone is true
 )
 ## [TriggerPath]
 

--- a/python/default_producers_cfi.py
+++ b/python/default_producers_cfi.py
@@ -369,7 +369,9 @@ icTriggerObjectProducer = cms.EDProducer('ICTriggerObjectProducer',
   branch = cms.string("triggerObjects"),
   input   = cms.InputTag("patTriggerEvent"),
   hltPath = cms.string(""),
-  storeOnlyIfFired = cms.bool(False)
+  storeOnlyIfFired = cms.bool(False),
+  inputIsStandAlone = cms.bool(False),
+  inputTriggerResults = cms.InputTag("TriggerResults", "", "HLT")
 )
 ## [TriggerObject]
 

--- a/src/TriggerPath.cc
+++ b/src/TriggerPath.cc
@@ -1,4 +1,6 @@
 #include "../interface/TriggerPath.hh"
+#include <iostream>
+#include "boost/format.hpp"
 
 namespace ic {
 TriggerPath::TriggerPath()
@@ -6,5 +8,10 @@ TriggerPath::TriggerPath()
 
 TriggerPath::~TriggerPath() {}
 
-void TriggerPath::Print() const {}
+void TriggerPath::Print() const {
+  std::string name = name_ != "" ? name_ : "<path name not saved>";
+  std::cout << boost::format(
+                   "%-65s accept=%-3i prescale=%-3i id=%-21i version=%-2i\n") %
+                   name % accept_ % prescale_ % id_ % version_;
+}
 }

--- a/test/miniaod_cfg.py
+++ b/test/miniaod_cfg.py
@@ -37,7 +37,7 @@ if release in ['70X']:
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.MessageLogger.cerr.FwkReport.reportEvery = 50
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(infile))
 # 53X: START53_V22::All (MC)
 # 70X: PLS170_V7AN1::All (MC)
@@ -453,10 +453,10 @@ process.patTriggerPath = cms.Path()
 if release in ['72X']:
  switchOnTrigger(process, path = 'patTriggerPath', outputModule = '')
 #
-#process.icTriggerPathProducer = producers.icTriggerPathProducer.clone(
-#  branch = cms.string("triggerPaths"),
-#  input  = cms.InputTag("patTriggerEvent")
-#)
+process.icTriggerPathProducer = producers.icTriggerPathProducer.clone(
+ branch = cms.string("triggerPaths"),
+ input  = cms.InputTag("patTriggerEvent")
+)
 
 ##############################################################################
 # TriggerObject Module
@@ -475,10 +475,12 @@ process.icTriggerObjectSequence = cms.Sequence(
 )
 
 if release in ['72XMINIAOD']:
-  for name in process.icTriggerObjectSequence.moduleNames():
-    mod = getattr(process, name)
-    mod.inputIsStandAlone = cms.bool(True)
-    mod.input = cms.InputTag("selectedPatTrigger")
+    process.icTriggerPathProducer.inputIsStandAlone = cms.bool(True)
+    process.icTriggerPathProducer.input = cms.InputTag("TriggerResults", "", "HLT")
+    for name in process.icTriggerObjectSequence.moduleNames():
+        mod = getattr(process, name)
+        mod.inputIsStandAlone = cms.bool(True)
+        mod.input = cms.InputTag("selectedPatTrigger", "", "PAT")
 
 
 ##############################################################################
@@ -494,7 +496,7 @@ process.icEventInfoProducer = producers.icEventInfoProducer.clone(
 process.icEventProducer = cms.EDProducer('ICEventProducer')
 
 process.p = cms.Path(
-  # process.icTriggerPathProducer+
+  process.icTriggerPathProducer+
   process.icTriggerObjectSequence+
   process.icEventProducer
   )

--- a/test/miniaod_cfg.py
+++ b/test/miniaod_cfg.py
@@ -20,7 +20,7 @@ infile      = opts.file
 tag         = opts.globalTag
 isData      = opts.isData
 release     = opts.release
-if not release in ["70X"]:
+if not release in ["72X", "72XMINIAOD"]:
     print 'Release not recognised, exiting!'
     sys.exit(1)
 print 'release     : '+release
@@ -447,11 +447,11 @@ if not isData:
 
 ##############################################################################
 # TriggerPath Modules
-##############################################################################
-#from PhysicsTools.PatAlgos.tools.trigTools import *
-#if release in ['70X']:
-#  process.patTriggerPath = cms.Path()
-#  switchOnTrigger(process, path = 'patTriggerPath', outputModule = '')
+#####################e#########################################################
+from PhysicsTools.PatAlgos.tools.trigTools import *
+process.patTriggerPath = cms.Path()
+if release in ['72X']:
+ switchOnTrigger(process, path = 'patTriggerPath', outputModule = '')
 #
 #process.icTriggerPathProducer = producers.icTriggerPathProducer.clone(
 #  branch = cms.string("triggerPaths"),
@@ -461,11 +461,25 @@ if not isData:
 ##############################################################################
 # TriggerObject Module
 ##############################################################################
-#process.icIsoMu24ObjectProducer = producers.icTriggerObjectProducer.clone(
-#  branch = cms.string("triggerObjectsIsoMu24"),
-#  input   = cms.InputTag("patTriggerEvent"),
-#  hltPath = cms.string("HLT_IsoMu24_eta2p1_v")
-#)
+
+process.icIsoMu17LooseTau20ObjectProducer = producers.icTriggerObjectProducer.clone(
+ branch = cms.string("triggerObjectsIsoMu17LooseTau20"),
+ input   = cms.InputTag("patTriggerEvent"),
+ hltPath = cms.string("HLT_IsoMu17_eta2p1_LooseIsoPFTau20_v"),
+ inputIsStandAlone = cms.bool(False),
+ storeOnlyIfFired = cms.bool(True)
+)
+
+process.icTriggerObjectSequence = cms.Sequence(
+  process.icIsoMu17LooseTau20ObjectProducer
+)
+
+if release in ['72XMINIAOD']:
+  for name in process.icTriggerObjectSequence.moduleNames():
+    mod = getattr(process, name)
+    mod.inputIsStandAlone = cms.bool(True)
+    mod.input = cms.InputTag("selectedPatTrigger")
+
 
 ##############################################################################
 # EventInfo Module
@@ -480,38 +494,12 @@ process.icEventInfoProducer = producers.icEventInfoProducer.clone(
 process.icEventProducer = cms.EDProducer('ICEventProducer')
 
 process.p = cms.Path(
-  process.ic70XExtraSequence+
-  #process.selectedPFCandidates+
-  #process.icCandidateProducer+
-  process.selectedVertices+
-  process.icVertexProducer+
-  process.pfIsoMiniAODSequence+
-  process.electronPFIsolationDepositsSequence+
-  process.electronPFIsolationValuesSequence+
-  process.selectedElectrons+
-  process.icElectronProducer+
-  process.muonPFIsolationDepositsSequence+
-  process.muonPFIsolationValuesSequence+
-  process.selectedMuons+
-  process.icMuonProducer+
-  #process.selectedPFTaus+
-  process.icTauProducer+
-  #process.selectedPhotons+
-  #process.icPhotonProducer+
-  #process.selectedPFJets+
-  process.icPFJetSequence+
-  #process.icPFJetProducer+
-  process.icPfMetProducer+
-  #process.selectedTracks+
-  #process.icTrackProducer+
-  process.icMCSequence+
-  #process.icTriggerPathProducer+
-  #process.icIsoMu24ObjectProducer+
-  process.icEventInfoProducer+
+  # process.icTriggerPathProducer+
+  process.icTriggerObjectSequence+
   process.icEventProducer
   )
 
-#process.schedule = cms.Schedule(process.patTriggerPath, process.p)
-process.schedule = cms.Schedule(process.p)
+process.schedule = cms.Schedule(process.patTriggerPath, process.p)
+#process.schedule = cms.Schedule(process.p)
 
 #print process.dumpPython()


### PR DESCRIPTION
Don't have access to the complete pat::TriggerEvent, so have to work around this using just the pat::TrigerObjects. Hopefully can just add a new "isMiniAOD" flag to the existing producers instead of having to write something completely new