### PR TITLE
Plotting with new CMS styles

### DIFF
--- a/Analysis/HiggsTauTau/interface/HTTPlotTools.h
+++ b/Analysis/HiggsTauTau/interface/HTTPlotTools.h
@@ -83,9 +83,9 @@ namespace ic {
       HTTPlot();
       boost::program_options::options_description const& GenerateOptions(std::string const& prefix);
       void GeneratePlot(HTTAnalysis::HistValueMap hmap);
-      static void SetMCStackStyle(ic::TH1PlotElement & ele, unsigned color);
-      static void SetSignalStyle(ic::TH1PlotElement & ele, unsigned color);
-      static void SetDataStyle(ic::TH1PlotElement & ele);
+      static void SetMCStackStyle(TH1* hist_ptr, unsigned color);
+      static void SetSignalStyle(TH1* hist_ptr, unsigned color);
+      static void SetDataStyle(TH1* hist_ptr);
       static void SetRatioStyle(ic::RatioPlotElement & ele, unsigned color);
       inline std::string plot_name() const { return plot_name_; }
       inline std::string draw_signal_mass() const { return draw_signal_mass_; }

--- a/Analysis/HiggsTauTau/interface/HTTPlotTools.h
+++ b/Analysis/HiggsTauTau/interface/HTTPlotTools.h
@@ -7,7 +7,6 @@
 #include "boost/algorithm/string.hpp"
 #include "boost/format.hpp"
 #include "boost/program_options.hpp"
-#include "UserCode/ICHiggsTauTau/Analysis/Core/interface/Plot.h"
 #include "UserCode/ICHiggsTauTau/Analysis/Core/interface/TextElement.h"
 #include "UserCode/ICHiggsTauTau/Analysis/Core/interface/ModuleBase.h"
 #include "UserCode/ICHiggsTauTau/Analysis/HiggsTauTau/interface/HTTAnalysisTools.h"
@@ -87,7 +86,6 @@ namespace ic {
       static void SetMCStackStyle(TH1* hist_ptr, unsigned color);
       static void SetSignalStyle(TH1* hist_ptr, unsigned color);
       static void SetDataStyle(TH1* hist_ptr);
-      static void SetRatioStyle(ic::RatioPlotElement & ele, unsigned color);
       inline std::string plot_name() const { return plot_name_; }
       inline std::string draw_signal_mass() const { return draw_signal_mass_; }
       inline std::string draw_signal_tanb() const { return draw_signal_tanb_; }

--- a/Analysis/HiggsTauTau/interface/HTTPlotTools.h
+++ b/Analysis/HiggsTauTau/interface/HTTPlotTools.h
@@ -62,8 +62,9 @@ namespace ic {
     CLASS_MEMBER(HTTPlot,   bool,           log_y)
     CLASS_MEMBER(HTTPlot,   bool,           draw_ratio)
     CLASS_MEMBER(HTTPlot,   bool,           norm_bins)
-    CLASS_MEMBER(HTTPlot,   std::string,    title_left)
-    CLASS_MEMBER(HTTPlot,   std::string,    title_right)
+    CLASS_MEMBER(HTTPlot,   std::string,    cms_label)
+    CLASS_MEMBER(HTTPlot,   std::string,    lumi_label)
+    CLASS_MEMBER(HTTPlot,   std::string,    cms_extra)
     CLASS_MEMBER(HTTPlot,   std::string,    background_scheme)
     CLASS_MEMBER(HTTPlot,   std::string,    signal_scheme)
     CLASS_MEMBER(HTTPlot,   std::string,    draw_signal_mass) // if "" then don't draw
@@ -97,8 +98,6 @@ namespace ic {
       inline double extra_pad() const { return extra_pad_; }
       inline std::string x_axis_label() const { return x_axis_label_; }
       inline std::string y_axis_label() const { return y_axis_label_; }
-      inline std::string title_left() const { return title_left_; }
-      inline std::string title_right() const { return title_right_; }
     private:
       boost::program_options::options_description config_;
       std::map<std::string, std::vector<PlotBkgComponent>> bkg_schemes_;

--- a/Analysis/HiggsTauTau/scripts/Hhh_control_plots_AN.sh
+++ b/Analysis/HiggsTauTau/scripts/Hhh_control_plots_AN.sh
@@ -66,129 +66,129 @@ then
 #### MET
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
   --norm_bins=true --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.1 \
   --background_scheme="et_default" $ET_INC_SHIFT 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
   --norm_bins=true --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.1 \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### pt_1
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="pt_1(25,0,100)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="pt_1(25,0,100)" \
   --x_axis_label="Electron p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
   
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="pt_1(25,0,100)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="pt_1(25,0,100)" \
   --x_axis_label="Muon p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### pt_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="pt_2(25,0,100)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="pt_2(25,0,100)" \
   --x_axis_label="Tau p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="pt_2(25,0,100)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="pt_2(25,0,100)" \
   --x_axis_label="Tau p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### pt_tt
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="pt_tt(30,0,300)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="pt_tt(30,0,300)" \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="pt_tt(30,0,300)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="pt_tt(30,0,300)" \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### pt_tt log
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="pt_tt(30,0,300)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="pt_tt(30,0,300)" \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" --log_y=true --draw_ratio=true \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="pt_tt(30,0,300)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="pt_tt(30,0,300)" \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" --log_y=true --draw_ratio=true \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### eta_1
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
   --x_axis_label="Electron #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
   --x_axis_label="Muon #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### eta_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="eta_2(30,-3,3)" --extra_pad=2.0 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_2(30,-3,3)" --extra_pad=2.0 \
   --x_axis_label="Tau #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="eta_2(30,-3,3)" --extra_pad=1.8 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_2(30,-3,3)" --extra_pad=1.8 \
   --x_axis_label="Tau #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### m_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="m_2(20,0,2)" --extra_pad=1.1 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="m_2(20,0,2)" --extra_pad=1.1 \
   --x_axis_label="Tau Mass [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="m_2(20,0,2)" --extra_pad=1.1\
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="m_2(20,0,2)" --extra_pad=1.1\
   --x_axis_label="Tau Mass [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-#  --method=8 --cat="pt_2>30. && tau_decay_mode==1" --var="m_2(20,0,2)" --extra_pad=1.5 \
+#  --method=28 --cat="pt_2>30. && tau_decay_mode==1" --var="m_2(20,0,2)" --extra_pad=1.5 \
 #  --x_axis_label="Tau Mass [GeV]" --datacard="1prong" \
 #  --background_scheme="et_default" $ET_INC_SHIFT
 
 #./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-#  --method=8 --cat="pt_2>30. && tau_decay_mode==1" --var="m_2(20,0,2)" --extra_pad=1.5\
+#  --method=28 --cat="pt_2>30. && tau_decay_mode==1" --var="m_2(20,0,2)" --extra_pad=1.5\
 #  --x_axis_label="Tau Mass [GeV]" --datacard="1prong" \
 #  --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-#  --method=8 --cat="pt_2>30. && tau_decay_mode==10" --var="m_2(20,0,2)" --extra_pad=1.5 \
+#  --method=28 --cat="pt_2>30. && tau_decay_mode==10" --var="m_2(20,0,2)" --extra_pad=1.5 \
 #  --x_axis_label="Tau Mass [GeV]" --datacard="3prong" \
 #  --background_scheme="et_default" $ET_INC_SHIFT
 
 #./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-#  --method=8 --cat="pt_2>30. && tau_decay_mode==10" --var="m_2(20,0,2)" --extra_pad=1.5 \
+#  --method=28 --cat="pt_2>30. && tau_decay_mode==10" --var="m_2(20,0,2)" --extra_pad=1.5 \
 #  --x_axis_label="Tau Mass [GeV]" --datacard="3prong" \
 #  --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### n_jets (log)
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="n_jets_csv(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_jets_csv(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
   --draw_ratio=true --log_y=true --extra_pad=5 --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="n_jets_csv(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_jets_csv(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
   --draw_ratio=true --log_y=true --extra_pad=5 --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
@@ -196,13 +196,13 @@ then
 #### n_bjets (log)
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="n_bjets_csv(9,-0.5,8.5)"  --x_axis_label="Number of b-tagged Jets" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_bjets_csv(9,-0.5,8.5)"  --x_axis_label="Number of b-tagged Jets" \
   --draw_ratio=true --log_y=true --extra_pad=500 --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="n_bjets_csv(9,-0.5,8.5)"  --x_axis_label="Number of b-tagged Jets" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_bjets_csv(9,-0.5,8.5)"  --x_axis_label="Number of b-tagged Jets" \
   --draw_ratio=true --log_y=true --extra_pad=500 --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
@@ -215,12 +215,12 @@ then
   MT_BINS="mt_1(20,0,160)"
 fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et  \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --set_alias="sel:1" --var=$MT_BINS \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --set_alias="sel:1" --var=$MT_BINS \
   --x_axis_label="m_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.8 $ET_BAND_ONLY \
   --background_scheme="et_default" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --set_alias="sel:1" --var=$MT_BINS \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --set_alias="sel:1" --var=$MT_BINS \
   --x_axis_label="m_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.8 $MT_BAND_ONLY \
   --background_scheme="mt_with_zmm"
 
@@ -228,12 +228,12 @@ fi
 #### n_vtx
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="n_vtx(30,0,30)" $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_vtx(30,0,30)" $ET_INC_SHIFT \
   --x_axis_label="Number of Vertices" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.8 \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="n_vtx(30,0,30)" $MT_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_vtx(30,0,30)" $MT_INC_SHIFT \
   --x_axis_label="Number of Vertices" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.8 \
   --background_scheme="mt_with_zmm"
 
@@ -241,13 +241,13 @@ fi
 #### tau_decay_mode
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="tau_decay_mode(3,-4,11)" $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="tau_decay_mode(3,-4,11)" $ET_INC_SHIFT \
   --x_axis_label="Tau Decay Mode" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=2.0 \
   --background_scheme="et_default"\
   --x_axis_bin_labels="1 Prong 0 #pi^{0}:1 Prong 1 #pi^{0}:3 Prong" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="tau_decay_mode(3,-4,11)" $MT_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="tau_decay_mode(3,-4,11)" $MT_INC_SHIFT \
   --x_axis_label="Tau Decay Mode" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=2.0 \
   --background_scheme="mt_with_zmm"\
   --x_axis_bin_labels="1 Prong 0 #pi^{0}:1 Prong 1 #pi^{0}:3 Prong" 
@@ -261,12 +261,12 @@ fi
 #### jet_csvpt_1
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_1(20,0,200)" $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_1(20,0,200)" $ET_INC_SHIFT \
   --x_axis_label="Leading selected jet p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" --extra_pad=1.3
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_1(20,0,200)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_1(20,0,200)" \
   --x_axis_label="Leading selected jet p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" $MT_INC_SHIFT \
   --background_scheme="mt_with_zmm" --extra_pad=1.3
 
@@ -277,24 +277,24 @@ then
   BETA_BINS="jet_csveta_1(15,-3,3)"
 fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 $ET_INC_SHIFT \
   --x_axis_label="Leading selected jet #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 \
   --x_axis_label="Leading selected jet #eta" --datacard="2jetinclusive"$MASSCUTS"" $MT_INC_SHIFT \
   --background_scheme="mt_with_zmm"
 
 #### jet_csvpt_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_2(20,0,200)" $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_2(20,0,200)" $ET_INC_SHIFT \
   --x_axis_label="Subleading selected jet p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" --extra_pad=1.3
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_2(20,0,200)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_2(20,0,200)" \
   --x_axis_label="Subleading selected jet p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" $MT_INC_SHIFT \
   --background_scheme="mt_with_zmm" --extra_pad=1.3
 
@@ -305,36 +305,36 @@ then
   BETA_BINS="jet_csveta_2(15,-3,3)"
 fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 $ET_INC_SHIFT \
   --x_axis_label="Subleading selected jet #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 \
   --x_axis_label="Subleading selected jet #eta" --datacard="2jetinclusive"$MASSCUTS"" $MT_INC_SHIFT \
   --background_scheme="mt_with_zmm"
 
 #### jet_csvcsv_1
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_1(25,0,1)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_1(25,0,1)" \
   --x_axis_label="Leading selected jet CSV" --datacard="2jetinclusive"$MASSCUTS""  $ET_INC_SHIFT \
   --background_scheme="et_default" --extra_pad=1.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_1(25,0,1)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_1(25,0,1)" \
   --x_axis_label="Leading selected jet CSV" --datacard="2jetinclusive"$MASSCUTS""  $MT_INC_SHIFT \
   --background_scheme="mt_with_zmm" --extra_pad=1.2
 
 #### jet_csvcsv_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_2(25,0,1)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_2(25,0,1)" \
   --x_axis_label="Subleading selected jet CSV" --datacard="2jetinclusive"$MASSCUTS""  $ET_INC_SHIFT \
   --background_scheme="et_default" --extra_pad=1.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_2(25,0,1)" \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_2(25,0,1)" \
   --x_axis_label="Subleading selected jet CSV" --datacard="2jetinclusive"$MASSCUTS""  $MT_INC_SHIFT \
   --background_scheme="mt_with_zmm" --extra_pad=1.2
 
@@ -342,13 +342,13 @@ fi
 #### jet_csvjdeta
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csv_deta(20,0,10)" $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csv_deta(20,0,10)" $ET_INC_SHIFT \
   --x_axis_label="#Delta#eta_{jj}" \
   --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" --extra_pad=1.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csv_deta(20,0,10)" $MT_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csv_deta(20,0,10)" $MT_INC_SHIFT \
   --x_axis_label="#Delta#eta_{jj}" \
   --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" --extra_pad=1.2

--- a/Analysis/HiggsTauTau/scripts/Hhh_control_plots_AN.sh
+++ b/Analysis/HiggsTauTau/scripts/Hhh_control_plots_AN.sh
@@ -67,12 +67,12 @@ then
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
-  --norm_bins=true --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.1 \
+  --norm_bins=true --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=0.2 \
   --background_scheme="et_default" $ET_INC_SHIFT 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
-  --norm_bins=true --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.1 \
+  --norm_bins=true --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=0.2 \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### pt_1
@@ -126,36 +126,36 @@ then
 #### eta_1
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_1(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Electron #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_1(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Muon #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### eta_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_2(30,-3,3)" --extra_pad=2.0 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_2(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Tau #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_2(30,-3,3)" --extra_pad=1.8 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="eta_2(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Tau #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 #### m_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="m_2(20,0,2)" --extra_pad=1.1 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="m_2(20,0,2)" --extra_pad=0.2 \
   --x_axis_label="Tau Mass [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="m_2(20,0,2)" --extra_pad=1.1\
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="m_2(20,0,2)" --extra_pad=0.2\
   --x_axis_label="Tau Mass [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
@@ -183,13 +183,13 @@ then
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_jets_csv(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=5 --datacard="2jetinclusive"$MASSCUTS"" \
+  --draw_ratio=true --log_y=true --extra_pad=0.4 --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_jets_csv(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=5 --datacard="2jetinclusive"$MASSCUTS"" \
+  --draw_ratio=true --log_y=true --extra_pad=0.4 --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
@@ -197,13 +197,13 @@ then
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_bjets_csv(9,-0.5,8.5)"  --x_axis_label="Number of b-tagged Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=500 --datacard="2jetinclusive"$MASSCUTS"" \
+  --draw_ratio=true --log_y=true --extra_pad=0.4 --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default" $ET_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_bjets_csv(9,-0.5,8.5)"  --x_axis_label="Number of b-tagged Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=500 --datacard="2jetinclusive"$MASSCUTS"" \
+  --draw_ratio=true --log_y=true --extra_pad=0.4 --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
@@ -216,12 +216,12 @@ then
 fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et  \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --set_alias="sel:1" --var=$MT_BINS \
-  --x_axis_label="m_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.8 $ET_BAND_ONLY \
+  --x_axis_label="m_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=0.4 $ET_BAND_ONLY \
   --background_scheme="et_default" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --set_alias="sel:1" --var=$MT_BINS \
-  --x_axis_label="m_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.8 $MT_BAND_ONLY \
+  --x_axis_label="m_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=0.4 $MT_BAND_ONLY \
   --background_scheme="mt_with_zmm"
 
 
@@ -229,12 +229,12 @@ fi
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_vtx(30,0,30)" $ET_INC_SHIFT \
-  --x_axis_label="Number of Vertices" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.8 \
+  --x_axis_label="Number of Vertices" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=0.4 \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="n_vtx(30,0,30)" $MT_INC_SHIFT \
-  --x_axis_label="Number of Vertices" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=1.8 \
+  --x_axis_label="Number of Vertices" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=0.4 \
   --background_scheme="mt_with_zmm"
 
 
@@ -242,13 +242,13 @@ fi
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="tau_decay_mode(3,-4,11)" $ET_INC_SHIFT \
-  --x_axis_label="Tau Decay Mode" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=2.0 \
+  --x_axis_label="Tau Decay Mode" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=0.4 \
   --background_scheme="et_default"\
   --x_axis_bin_labels="1 Prong 0 #pi^{0}:1 Prong 1 #pi^{0}:3 Prong" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="tau_decay_mode(3,-4,11)" $MT_INC_SHIFT \
-  --x_axis_label="Tau Decay Mode" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=2.0 \
+  --x_axis_label="Tau Decay Mode" --datacard="2jetinclusive"$MASSCUTS"" --extra_pad=0.4 \
   --background_scheme="mt_with_zmm"\
   --x_axis_bin_labels="1 Prong 0 #pi^{0}:1 Prong 1 #pi^{0}:3 Prong" 
 
@@ -263,12 +263,12 @@ fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_1(20,0,200)" $ET_INC_SHIFT \
   --x_axis_label="Leading selected jet p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
-  --background_scheme="et_default" --extra_pad=1.3
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_1(20,0,200)" \
   --x_axis_label="Leading selected jet p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" $MT_INC_SHIFT \
-  --background_scheme="mt_with_zmm" --extra_pad=1.3
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 #### jet_csveta_1
 BETA_BINS="jet_csveta_1(10,-3,3)"
@@ -277,12 +277,12 @@ then
   BETA_BINS="jet_csveta_1(15,-3,3)"
 fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=0.4 $ET_INC_SHIFT \
   --x_axis_label="Leading selected jet #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=0.4 \
   --x_axis_label="Leading selected jet #eta" --datacard="2jetinclusive"$MASSCUTS"" $MT_INC_SHIFT \
   --background_scheme="mt_with_zmm"
 
@@ -291,12 +291,12 @@ fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_2(20,0,200)" $ET_INC_SHIFT \
   --x_axis_label="Subleading selected jet p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" \
-  --background_scheme="et_default" --extra_pad=1.3
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvpt_2(20,0,200)" \
   --x_axis_label="Subleading selected jet p_{T} [GeV]" --datacard="2jetinclusive"$MASSCUTS"" $MT_INC_SHIFT \
-  --background_scheme="mt_with_zmm" --extra_pad=1.3
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 #### jet_csveta_2
 BETA_BINS="jet_csveta_2(10,-3,3)"
@@ -305,12 +305,12 @@ then
   BETA_BINS="jet_csveta_2(15,-3,3)"
 fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 $ET_INC_SHIFT \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=0.4 $ET_INC_SHIFT \
   --x_axis_label="Subleading selected jet #eta" --datacard="2jetinclusive"$MASSCUTS"" \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=2.0 \
+  --method=28 --cat="2jetinclusive"$MASSCUTS"" --var=$BETA_BINS --extra_pad=0.4 \
   --x_axis_label="Subleading selected jet #eta" --datacard="2jetinclusive"$MASSCUTS"" $MT_INC_SHIFT \
   --background_scheme="mt_with_zmm"
 
@@ -319,24 +319,24 @@ fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_1(25,0,1)" \
   --x_axis_label="Leading selected jet CSV" --datacard="2jetinclusive"$MASSCUTS""  $ET_INC_SHIFT \
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_1(25,0,1)" \
   --x_axis_label="Leading selected jet CSV" --datacard="2jetinclusive"$MASSCUTS""  $MT_INC_SHIFT \
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 #### jet_csvcsv_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_2(25,0,1)" \
   --x_axis_label="Subleading selected jet CSV" --datacard="2jetinclusive"$MASSCUTS""  $ET_INC_SHIFT \
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csvbcsv_2(25,0,1)" \
   --x_axis_label="Subleading selected jet CSV" --datacard="2jetinclusive"$MASSCUTS""  $MT_INC_SHIFT \
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 
 #### jet_csvjdeta
@@ -345,12 +345,12 @@ fi
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csv_deta(20,0,10)" $ET_INC_SHIFT \
   --x_axis_label="#Delta#eta_{jj}" \
   --datacard="2jetinclusive"$MASSCUTS"" \
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=28 --cat="2jetinclusive"$MASSCUTS"" --var="jet_csv_deta(20,0,10)" $MT_INC_SHIFT \
   --x_axis_label="#Delta#eta_{jj}" \
   --datacard="2jetinclusive"$MASSCUTS"" \
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 

--- a/Analysis/HiggsTauTau/scripts/Hhh_mass_plots_AN.sh
+++ b/Analysis/HiggsTauTau/scripts/Hhh_mass_plots_AN.sh
@@ -67,7 +67,7 @@ then
 if [ "$MASSCUTS" = "MassCuts" ]
 then
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --var="m_sv"["$MSSMBINS"] --cat="2jet0tagSFMassCutMbb" \
+  --method=28 --var="m_sv"["$MSSMBINS"] --cat="2jet0tagSFMassCutMbb" \
   --x_axis_label="M_{#tau#tau} [GeV]" $MT_INC_SHIFT \
   --norm_bins=true --datacard="2jet0tagSFMassCutMbb" --y_axis_label="dN/dm_{#tau#tau} [1/GeV]" \
   --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -75,7 +75,7 @@ then
   --background_scheme="mt_with_zmm" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --var="m_sv"["$MSSMBINS"] --cat="2jet0tagSFMassCutMbb" \
+  --method=28 --var="m_sv"["$MSSMBINS"] --cat="2jet0tagSFMassCutMbb" \
   --x_axis_label="M_{#tau#tau} [GeV]" $ET_INC_SHIFT \
   --norm_bins=true --datacard="2jet0tagSFMassCutMbb" --y_axis_label="dN/dm_{#tau#tau} [1/GeV]" \
   --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -117,7 +117,7 @@ else
 #### svfit mass
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-    --method=8 --var="m_sv"["$MSSMBINS"] --cat="2jet0tagSF" \
+    --method=28 --var="m_sv"["$MSSMBINS"] --cat="2jet0tagSF" \
     --x_axis_label="M_{#tau#tau} [GeV]" $MT_INC_SHIFT \
     --norm_bins=true --datacard="2jet0tagSF" --y_axis_label="dN/dm_{#tau#tau} [1/GeV]" \
     --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -125,7 +125,7 @@ else
     --background_scheme="mt_with_zmm" 
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-    --method=8 --var="m_sv"["$MSSMBINS"] --cat="2jet0tagSF" \
+    --method=28 --var="m_sv"["$MSSMBINS"] --cat="2jet0tagSF" \
     --x_axis_label="M_{#tau#tau} [GeV]" $ET_INC_SHIFT \
     --norm_bins=true --datacard="2jet0tagSF" --y_axis_label="dN/dm_{#tau#tau} [1/GeV]" \
     --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -170,13 +170,13 @@ fi
 if [ "$MASSCUTS" = "MassCuts" ]
 then
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-    --method=8 --cat="2jet0tagSFMassCutMtt" --var="jet_csv_mjj(30,0,600)" $ET_INC_SHIFT \
+    --method=28 --cat="2jet0tagSFMassCutMtt" --var="jet_csv_mjj(30,0,600)" $ET_INC_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet0tagSFMassCutMtt" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
     --background_scheme="et_default" --extra_pad=1.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-    --method=8 --cat="2jet0tagSFMassCutMtt" --var="jet_csv_mjj(30,0,600)" $MT_INC_SHIFT \
+    --method=28 --cat="2jet0tagSFMassCutMtt" --var="jet_csv_mjj(30,0,600)" $MT_INC_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet0tagSFMassCutMtt" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
     --background_scheme="mt_with_zmm" --extra_pad=1.2
@@ -208,13 +208,13 @@ else
 #### m_bb
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-    --method=8 --cat="2jet0tagSF" --var="jet_csv_mjj(30,0,600)" $ET_INC_SHIFT \
+    --method=28 --cat="2jet0tagSF" --var="jet_csv_mjj(30,0,600)" $ET_INC_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet0tagSF" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
     --background_scheme="et_default" --extra_pad=1.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-    --method=8 --cat="2jet0tagSF" --var="jet_csv_mjj(30,0,600)" $MT_INC_SHIFT \
+    --method=28 --cat="2jet0tagSF" --var="jet_csv_mjj(30,0,600)" $MT_INC_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet0tagSF" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
     --background_scheme="mt_with_zmm" --extra_pad=1.2
@@ -303,7 +303,7 @@ then
 else
 #### m_ttbb
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --var="mjj_tt"["$HIGGSMASSBINS"] --cat="2jet0tagSF" --y_axis_label="dN/dm_{#tau#tau+jj} [1/GeV]"\
+  --method=28 --var="mjj_tt"["$HIGGSMASSBINS"] --cat="2jet0tagSF" --y_axis_label="dN/dm_{#tau#tau+jj} [1/GeV]"\
   --x_axis_label="M_{#tau#tau+jj} [GeV]" $ET_INC_SHIFT \
   --norm_bins=true --datacard="2jet0tagSF"  \
   --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -311,7 +311,7 @@ else
   --background_scheme="et_default" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --var="mjj_tt"["$HIGGSMASSBINS"] --cat="2jet0tagSF" --y_axis_label="dN/dm_{#tau#tau+jj} [1/GeV]"\
+  --method=28 --var="mjj_tt"["$HIGGSMASSBINS"] --cat="2jet0tagSF" --y_axis_label="dN/dm_{#tau#tau+jj} [1/GeV]"\
   --x_axis_label="M_{#tau#tau+jj} [GeV]" $MT_INC_SHIFT \
   --norm_bins=true --datacard="2jet0tagSF"  \
   --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -408,7 +408,7 @@ then
 else
 #### m_H
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --var="m_H_hh"["$KINFITMASSBINS"] --cat="2jet0tagSF" --y_axis_label="dN/dm_{H}^{kinfit} [1/GeV]"\
+  --method=28 --var="m_H_hh"["$KINFITMASSBINS"] --cat="2jet0tagSF" --y_axis_label="dN/dm_{H}^{kinfit} [1/GeV]"\
   --x_axis_label="M_{H}^{kinfit} [GeV]" $ET_INC_SHIFT \
   --norm_bins=true --datacard="2jet0tagSF"  \
   --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -416,7 +416,7 @@ else
   --background_scheme="et_default" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --var="m_H_hh"["$KINFITMASSBINS"] --cat="2jet0tagSF" --y_axis_label="dN/dm_{H}^{kinfit} [1/GeV]"\
+  --method=28 --var="m_H_hh"["$KINFITMASSBINS"] --cat="2jet0tagSF" --y_axis_label="dN/dm_{H}^{kinfit} [1/GeV]"\
   --x_axis_label="M_{H}^{kinfit} [GeV]" $MT_INC_SHIFT \
   --norm_bins=true --datacard="2jet0tagSF"  \
   --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -510,7 +510,7 @@ then
   --background_scheme="mt_with_zmm" 
 else
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --var="m_H_hh_chi2(25,0,100)" --cat="2jet0tagSF" --y_axis_label="Events"\
+  --method=28 --var="m_H_hh_chi2(25,0,100)" --cat="2jet0tagSF" --y_axis_label="Events"\
   --x_axis_label="chi2" $ET_INC_SHIFT \
   --norm_bins=false --datacard="2jet0tagSF"  \
   --custom_y_axis_min=true --y_axis_min=0.0099 \
@@ -518,7 +518,7 @@ else
   --background_scheme="et_default" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --var="m_H_hh_chi2(25,0,100)" --cat="2jet0tagSF" --y_axis_label="Events"\
+  --method=28 --var="m_H_hh_chi2(25,0,100)" --cat="2jet0tagSF" --y_axis_label="Events"\
   --x_axis_label="chi2" $MT_INC_SHIFT \
   --norm_bins=false --datacard="2jet0tagSF"  \
   --custom_y_axis_min=true --y_axis_min=0.0099 \

--- a/Analysis/HiggsTauTau/scripts/Hhh_mass_plots_AN.sh
+++ b/Analysis/HiggsTauTau/scripts/Hhh_mass_plots_AN.sh
@@ -173,37 +173,37 @@ then
     --method=28 --cat="2jet0tagSFMassCutMtt" --var="jet_csv_mjj(30,0,600)" $ET_INC_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet0tagSFMassCutMtt" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="et_default" --extra_pad=1.2
+    --background_scheme="et_default" --extra_pad=0.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
     --method=28 --cat="2jet0tagSFMassCutMtt" --var="jet_csv_mjj(30,0,600)" $MT_INC_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet0tagSFMassCutMtt" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="mt_with_zmm" --extra_pad=1.2
+    --background_scheme="mt_with_zmm" --extra_pad=0.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
     --method=24 --cat="2jet1tagSFMassCutMtt" --var="jet_csv_mjj(30,0,600)" $ET_2JET1TAG_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet1tagSFMassCutMtt" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="et_default" --extra_pad=1.2
+    --background_scheme="et_default" --extra_pad=0.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
     --method=24 --cat="2jet1tagSFMassCutMtt" --var="jet_csv_mjj(30,0,600)" $MT_2JET1TAG_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet1tagSFMassCutMtt" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="mt_with_zmm" --extra_pad=1.2
+    --background_scheme="mt_with_zmm" --extra_pad=0.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
     --method=27 --cat="2jet2tagSFMassCutMtt" --var="jet_csv_mjj(15,0,600)" $ET_2JET2TAG_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet2tagSFMassCutMtt" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="et_default" --extra_pad=1.2 --fix_negative_bins="QCD"
+    --background_scheme="et_default" --extra_pad=0.2 --fix_negative_bins="QCD"
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
     --method=27 --cat="2jet2tagSFMassCutMtt" --var="jet_csv_mjj(15,0,600)" $MT_2JET2TAG_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet2tagSFMassCutMtt" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="mt_with_zmm" --extra_pad=1.2 --fix_negative_bins="QCD"
+    --background_scheme="mt_with_zmm" --extra_pad=0.2 --fix_negative_bins="QCD"
 else
 #### m_bb
 
@@ -211,37 +211,37 @@ else
     --method=28 --cat="2jet0tagSF" --var="jet_csv_mjj(30,0,600)" $ET_INC_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet0tagSF" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="et_default" --extra_pad=1.2
+    --background_scheme="et_default" --extra_pad=0.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
     --method=28 --cat="2jet0tagSF" --var="jet_csv_mjj(30,0,600)" $MT_INC_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet0tagSF" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="mt_with_zmm" --extra_pad=1.2
+    --background_scheme="mt_with_zmm" --extra_pad=0.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
     --method=24 --cat="2jet1tagSF" --var="jet_csv_mjj(30,0,600)" $ET_2JET1TAG_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet1tagSF" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="et_default" --extra_pad=1.2
+    --background_scheme="et_default" --extra_pad=0.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
     --method=24 --cat="2jet1tagSF" --var="jet_csv_mjj(30,0,600)" $MT_2JET1TAG_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet1tagSF" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="mt_with_zmm" --extra_pad=1.2
+    --background_scheme="mt_with_zmm" --extra_pad=0.2
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
     --method=27 --cat="2jet2tagSF" --var="jet_csv_mjj(15,0,600)" $ET_2JET2TAG_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet2tagSF" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="et_default" --extra_pad=1.2 --fix_negative_bins="QCD"
+    --background_scheme="et_default" --extra_pad=0.2 --fix_negative_bins="QCD"
 
   ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
     --method=27 --cat="2jet2tagSF" --var="jet_csv_mjj(15,0,600)" $MT_2JET2TAG_SHIFT \
     --x_axis_label="M_{jj} [GeV]" --norm_bins=true --datacard="2jet2tagSF" --y_axis_label="dN/dm_{jj} [1/GeV]"\
     --blind=false --x_blind_min=80 --x_blind_max=160 \
-    --background_scheme="mt_with_zmm" --extra_pad=1.2 --fix_negative_bins="QCD"
+    --background_scheme="mt_with_zmm" --extra_pad=0.2 --fix_negative_bins="QCD"
 
 fi
 

--- a/Analysis/HiggsTauTau/scripts/new_plot_control.sh
+++ b/Analysis/HiggsTauTau/scripts/new_plot_control.sh
@@ -160,19 +160,19 @@ echo "Applying 7TeV scale factors..."
   --method=8 --var="m_vis"["$SMBINS"] --cat="inclusive" \
   --x_axis_label="M_{#tau#tau}^{vis} [GeV]" $ET_INC_SHIFT \
   --norm_bins=true --datacard="inclusive"\
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --var="m_vis"["$SMBINS"] --cat="inclusive" \
   --x_axis_label="M_{#tau#tau}^{vis} [GeV]" $MT_INC_SHIFT \
   --norm_bins=true --datacard="inclusive"\
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --var="m_vis"["$SMBINS"] --cat="inclusive" \
   --x_axis_label="M_{#tau#tau}^{vis} [GeV]" $EM_INC_SHIFT \
   --norm_bins=true --datacard="inclusive"\
-  --background_scheme="em_default" --extra_pad=1.2
+  --background_scheme="em_default" --extra_pad=0.2
 
 #### Visible Mass MSSM
 
@@ -204,18 +204,18 @@ echo "Applying 7TeV scale factors..."
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
-  --norm_bins=true --datacard="inclusive" --extra_pad=1.1 \
+  --norm_bins=true --datacard="inclusive" --extra_pad=0.2 \
   --background_scheme="et_default" $ET_INC_SHIFT 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
-  --norm_bins=true --datacard="inclusive" --extra_pad=1.1 \
+  --norm_bins=true --datacard="inclusive" --extra_pad=0.2 \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="inclusive" --var="met(20,0,100)" --x_axis_label="E_{T}^{miss} [GeV]" \
   --custom_x_axis_range=true --x_axis_min=0 --x_axis_max=100 \
-  --norm_bins=true --datacard="inclusive" --extra_pad=1.1 \
+  --norm_bins=true --datacard="inclusive" --extra_pad=0.2 \
   --background_scheme="em_default" $EM_INC_SHIFT
 
 #### pt_1
@@ -255,100 +255,100 @@ echo "Applying 7TeV scale factors..."
 #### pt_tt
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" \
+  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" --extra_pad=0.3 \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="inclusive" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" \
+  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" --extra_pad=0.3  \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="inclusive" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
-  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" \
+  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" --extra_pad=0.3  \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="inclusive" \
   --background_scheme="em_default" $EM_INC_SHIFT
 
 #### pt_tt log
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" \
+  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" --extra_pad=0.3  \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="inclusive" --log_y=true --draw_ratio=true \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" \
+  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)"  --extra_pad=0.3 \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="inclusive" --log_y=true --draw_ratio=true \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
-  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)" \
+  --method=8 --cat="inclusive" --var="pt_tt(30,0,300)"  --extra_pad=0.3 \
   --x_axis_label="p_{T}^{#tau#tau} [GeV]" --datacard="inclusive" --log_y=true --draw_ratio=true \
   --background_scheme="em_default" $EM_INC_SHIFT
 
 #### eta_1
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
+  --method=8 --cat="inclusive" --var="eta_1(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Electron #eta" --datacard="inclusive" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
+  --method=8 --cat="inclusive" --var="eta_1(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Muon #eta" --datacard="inclusive" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5"\
-  --method=8 --cat="inclusive" --var="eta_1(30,-3,3)" --extra_pad=1.9 \
+  --method=8 --cat="inclusive" --var="eta_1(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Electron #eta" --datacard="inclusive" \
   --background_scheme="em_default" $EM_INC_SHIFT
 
 #### eta_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="eta_2(30,-3,3)" --extra_pad=2.0 \
+  --method=8 --cat="inclusive" --var="eta_2(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Tau #eta" --datacard="inclusive" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="eta_2(30,-3,3)" --extra_pad=1.8 \
+  --method=8 --cat="inclusive" --var="eta_2(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Tau #eta" --datacard="inclusive" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5"\
-  --method=8 --cat="inclusive" --var="eta_2(30,-3,3)" --extra_pad=1.8 \
+  --method=8 --cat="inclusive" --var="eta_2(30,-3,3)" --extra_pad=0.4 \
   --x_axis_label="Muon #eta" --datacard="inclusive" \
   --background_scheme="em_default" $EM_INC_SHIFT
 
 #### m_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="m_2(20,0,2)" --extra_pad=1.1 \
+  --method=8 --cat="inclusive" --var="m_2(20,0,2)" --extra_pad=0.2 \
   --x_axis_label="Tau Mass [GeV]" --datacard="inclusive" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="inclusive" --var="m_2(20,0,2)" --extra_pad=1.1\
+  --method=8 --cat="inclusive" --var="m_2(20,0,2)" --extra_pad=0.2\
   --x_axis_label="Tau Mass [GeV]" --datacard="inclusive" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="pt_2>30. && tau_decay_mode==1" --var="m_2(20,0,2)" --extra_pad=1.5 \
+  --method=8 --cat="pt_2>30. && tau_decay_mode==1" --var="m_2(20,0,2)" --extra_pad=0.5 \
   --x_axis_label="Tau Mass [GeV]" --datacard="1prong" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="pt_2>30. && tau_decay_mode==1" --var="m_2(20,0,2)" --extra_pad=1.5\
+  --method=8 --cat="pt_2>30. && tau_decay_mode==1" --var="m_2(20,0,2)" --extra_pad=0.5\
   --x_axis_label="Tau Mass [GeV]" --datacard="1prong" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="pt_2>30. && tau_decay_mode==10" --var="m_2(20,0,2)" --extra_pad=1.5 \
+  --method=8 --cat="pt_2>30. && tau_decay_mode==10" --var="m_2(20,0,2)" --extra_pad=0.5 \
   --x_axis_label="Tau Mass [GeV]" --datacard="3prong" \
   --background_scheme="et_default" $ET_INC_SHIFT
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="pt_2>30. && tau_decay_mode==10" --var="m_2(20,0,2)" --extra_pad=1.5 \
+  --method=8 --cat="pt_2>30. && tau_decay_mode==10" --var="m_2(20,0,2)" --extra_pad=0.5 \
   --x_axis_label="Tau Mass [GeV]" --datacard="3prong" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT
 
@@ -356,19 +356,19 @@ echo "Applying 7TeV scale factors..."
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="n_jets(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=5 --datacard="inclusive" \
+  --draw_ratio=true --log_y=true --extra_pad=0.3 --datacard="inclusive" \
   --background_scheme="et_default" $ET_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="n_jets(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=5 --datacard="inclusive" \
+  --draw_ratio=true --log_y=true --extra_pad=0.3 --datacard="inclusive" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="inclusive" --var="n_jets(10,-0.5,9.5)"  --x_axis_label="Number of Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=5 --datacard="inclusive" \
+  --draw_ratio=true --log_y=true --extra_pad=0.3 --datacard="inclusive" \
   --background_scheme="em_default" $EM_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
@@ -376,19 +376,19 @@ echo "Applying 7TeV scale factors..."
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="n_bjets(5,-0.5,4.5)"  --x_axis_label="Number of b-tagged Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=5 --datacard="inclusive" \
+  --draw_ratio=true --log_y=true --extra_pad=0.3 --datacard="inclusive" \
   --background_scheme="et_default" $ET_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="n_bjets(5,-0.5,4.5)"  --x_axis_label="Number of b-tagged Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=5 --datacard="inclusive" \
+  --draw_ratio=true --log_y=true --extra_pad=0.3 --datacard="inclusive" \
   --background_scheme="mt_with_zmm" $MT_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="inclusive" --var="n_bjets(5,-0.5,4.5)"  --x_axis_label="Number of b-tagged Jets" \
-  --draw_ratio=true --log_y=true --extra_pad=5 --datacard="inclusive" \
+  --draw_ratio=true --log_y=true --extra_pad=0.3 --datacard="inclusive" \
   --background_scheme="em_default" $EM_INC_SHIFT \
   --custom_y_axis_min=true --y_axis_min=0.99
 
@@ -396,51 +396,51 @@ echo "Applying 7TeV scale factors..."
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et  \
   --method=8 --cat="inclusive" --set_alias="sel:1" --var="mt_1(40,0,160)" \
-  --x_axis_label="m_{T} [GeV]" --datacard="inclusive" --extra_pad=1.1 $ET_BAND_ONLY \
+  --x_axis_label="m_{T} [GeV]" --datacard="inclusive" --extra_pad=0.2 $ET_BAND_ONLY \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt \
   --method=8 --cat="inclusive" --set_alias="sel:1" --var="mt_1(40,0,160)" \
-  --x_axis_label="m_{T} [GeV]" --datacard="inclusive" --extra_pad=1.1 $MT_BAND_ONLY \
+  --x_axis_label="m_{T} [GeV]" --datacard="inclusive" --extra_pad=0.2 $MT_BAND_ONLY \
   --background_scheme="mt_with_zmm"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:1" \
-  --method=8 --cat="inclusive" --var="pzeta(48,-100,100)" --extra_pad=1.5 $EM_BAND_ONLY \
+  --method=8 --cat="inclusive" --var="pzeta(48,-100,100)" --extra_pad=0.3 $EM_BAND_ONLY \
   --x_axis_label="D_{#zeta} [GeV]" --datacard="inclusive" \
-  --background_scheme="em_default" --extra_pad=1.4
+  --background_scheme="em_default" --extra_pad=0.3
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:1" \
   --method=8 --cat="inclusive" --var="pzetavis(25,0,50)"  $EM_BAND_ONLY \
   --x_axis_label="P_{#zeta}^{vis} [GeV]" --datacard="inclusive" \
-  --background_scheme="em_default" --extra_pad=1.2
+  --background_scheme="em_default" --extra_pad=0.2
 
  ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:1" \
   --method=8 --cat="inclusive" --var="pzetamiss(25,-100,100)"  $EM_BAND_ONLY \
   --x_axis_label="#slash{P}_{#zeta} [GeV]" --datacard="inclusive" \
-  --background_scheme="em_default" --extra_pad=2.0
+  --background_scheme="em_default" --extra_pad=0.3
 
  ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:1" \
-  --method=8 --cat="inclusive" --var="em_gf_mva(40,-1,1)" --extra_pad=1. $EM_BAND_ONLY \
+  --method=8 --cat="inclusive" --var="em_gf_mva(40,-1,1)" --extra_pad=0.2 $EM_BAND_ONLY \
   --x_axis_label="BDT output" --datacard="inclusive" \
   --background_scheme="em_default"
  
  ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:1" \
-  --method=8 --cat="inclusive" --var="em_gf_mva(40,-1,1)" --extra_pad=100. $EM_BAND_ONLY \
+  --method=8 --cat="inclusive" --var="em_gf_mva(40,-1,1)" --extra_pad=0.3 $EM_BAND_ONLY \
   --x_axis_label="BDT output" --datacard="inclusive" --log_y=true --draw_ratio=true \
   --background_scheme="em_default"
  
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:1" \
   --method=8 --cat="inclusive" --var="mt_ll(40,0,160)" $EM_BAND_ONLY \
   --x_axis_label="m_{T}(ll) [GeV]" --datacard="inclusive" \
-  --background_scheme="em_default" --extra_pad=1.3
+  --background_scheme="em_default" --extra_pad=0.3
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:1" \
-  --method=8 --cat="inclusive" --var="emu_dphi(40,0,3.15)" --extra_pad=1.5 $EM_BAND_ONLY \
+  --method=8 --cat="inclusive" --var="emu_dphi(40,0,3.15)" --extra_pad=0.3 $EM_BAND_ONLY \
   --x_axis_label="#Delta#phi_{e,#mu}" --datacard="inclusive" \
   --background_scheme="em_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:1" \
-  --method=8 --cat="inclusive" --var="emu_dxy_1(40,-0.02,0.02)" --extra_pad=100 --log_y=true --draw_ratio=true \
+  --method=8 --cat="inclusive" --var="emu_dxy_1(40,-0.02,0.02)" --extra_pad=0.3 --log_y=true --draw_ratio=true \
   --x_axis_label="Electron d_{0}^{vtx} [cm]" --datacard="inclusive" $EM_BAND_ONLY \
   --background_scheme="em_default"
 
@@ -448,30 +448,30 @@ echo "Applying 7TeV scale factors..."
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="n_vtx(30,0,30)" $ET_INC_SHIFT \
-  --x_axis_label="Number of Vertices" --datacard="inclusive" --extra_pad=1.8 \
+  --x_axis_label="Number of Vertices" --datacard="inclusive" --extra_pad=0.4 \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="n_vtx(30,0,30)" $MT_INC_SHIFT \
-  --x_axis_label="Number of Vertices" --datacard="inclusive" --extra_pad=1.8 \
+  --x_axis_label="Number of Vertices" --datacard="inclusive" --extra_pad=0.4 \
   --background_scheme="mt_with_zmm"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="inclusive" --var="n_vtx(30,0,30)" $EM_INC_SHIFT \
-  --x_axis_label="Number of Vertices" --datacard="inclusive" --extra_pad=1.8 \
+  --x_axis_label="Number of Vertices" --datacard="inclusive" --extra_pad=0.4 \
   --background_scheme="em_default"
 
 #### tau_decay_mode
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="tau_decay_mode(3,-4,11)" $ET_INC_SHIFT \
-  --x_axis_label="Tau Decay Mode" --datacard="inclusive" --extra_pad=2.0 \
+  --x_axis_label="Tau Decay Mode" --datacard="inclusive" --extra_pad=0.5 \
   --background_scheme="et_default"\
   --x_axis_bin_labels="1 Prong 0 #pi^{0}:1 Prong 1 #pi^{0}:3 Prong" 
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="inclusive" --var="tau_decay_mode(3,-4,11)" $MT_INC_SHIFT \
-  --x_axis_label="Tau Decay Mode" --datacard="inclusive" --extra_pad=2.0 \
+  --x_axis_label="Tau Decay Mode" --datacard="inclusive" --extra_pad=0.5 \
   --background_scheme="mt_with_zmm"\
   --x_axis_bin_labels="1 Prong 0 #pi^{0}:1 Prong 1 #pi^{0}:3 Prong" 
 
@@ -485,32 +485,32 @@ echo "Applying 7TeV scale factors..."
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="1jet" --var="jpt_1(20,0,200)" $ET_1JET_SHIFT \
   --x_axis_label="Leading Jet p_{T} [GeV]" --datacard="1jet" \
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="1jet" --var="jpt_1(20,0,200)" $MT_1JET_SHIFT \
   --x_axis_label="Leading Jet p_{T} [GeV]" --datacard="1jet" \
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="1jet" --var="jpt_1(20,0,200)" $EM_1JET_SHIFT \
   --x_axis_label="Leading Jet p_{T} [GeV]" --datacard="1jet" \
-  --background_scheme="em_default" --extra_pad=1.2
+  --background_scheme="em_default" --extra_pad=0.2
 
 #### jeta_1
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="1jet" --var="jeta_1(20,-5,5)" --extra_pad=2.0 $ET_1JET_SHIFT \
+  --method=8 --cat="1jet" --var="jeta_1(20,-5,5)" --extra_pad=0.5 $ET_1JET_SHIFT \
   --x_axis_label="Leading Jet #eta [GeV]" --datacard="1jet" \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="1jet" --var="jeta_1(20,-5,5)" --extra_pad=1.9 $MT_1JET_SHIFT \
+  --method=8 --cat="1jet" --var="jeta_1(20,-5,5)" --extra_pad=0.5 $MT_1JET_SHIFT \
   --x_axis_label="Leading Jet #eta [GeV]" --datacard="1jet" \
   --background_scheme="mt_with_zmm"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
-  --method=8 --cat="1jet" --var="jeta_1(20,-5,5)" --extra_pad=1.9 $EM_1JET_SHIFT \
+  --method=8 --cat="1jet" --var="jeta_1(20,-5,5)" --extra_pad=0.5 $EM_1JET_SHIFT \
   --x_axis_label="Leading Jet #eta [GeV]" --datacard="1jet" \
   --background_scheme="em_default"
 
@@ -519,32 +519,32 @@ echo "Applying 7TeV scale factors..."
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="twojet" --var="jpt_2(20,0,200)" $ET_2JET_SHIFT \
   --x_axis_label="Subleading Jet p_{T} [GeV]" --datacard="twojet" \
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="twojet" --var="jpt_2(20,0,200)" $MT_2JET_SHIFT \
   --x_axis_label="Subleading Jet p_{T} [GeV]" --datacard="twojet" \
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="twojet" --var="jpt_2(20,0,200)" $EM_2JET_SHIFT \
   --x_axis_label="Subleading Jet p_{T} [GeV]" --datacard="twojet" \
-  --background_scheme="em_default" --extra_pad=1.2
+  --background_scheme="em_default" --extra_pad=0.2
 
 #### jeta_2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="twojet" --var="jeta_2(20,-5,5)" --extra_pad=1.9 $ET_2JET_SHIFT \
+  --method=8 --cat="twojet" --var="jeta_2(20,-5,5)" --extra_pad=0.5 $ET_2JET_SHIFT \
   --x_axis_label="Subleading Jet #eta [GeV]" --datacard="twojet" \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="twojet" --var="jeta_2(20,-5,5)" --extra_pad=1.9 $MT_2JET_SHIFT \
+  --method=8 --cat="twojet" --var="jeta_2(20,-5,5)" --extra_pad=0.5 $MT_2JET_SHIFT \
   --x_axis_label="Subleading Jet #eta [GeV]" --datacard="twojet" \
   --background_scheme="mt_with_zmm"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
-  --method=8 --cat="twojet" --var="jeta_2(20,-5,5)" --extra_pad=1.9 $EM_2JET_SHIFT \
+  --method=8 --cat="twojet" --var="jeta_2(20,-5,5)" --extra_pad=0.5 $EM_2JET_SHIFT \
   --x_axis_label="Subleading Jet #eta [GeV]" --datacard="twojet" \
   --background_scheme="em_default"
 
@@ -553,17 +553,17 @@ echo "Applying 7TeV scale factors..."
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="btag" --var="bpt_1(20,0,200)" $ET_BTAG_SHIFT \
   --x_axis_label="Leading b-tagged jet p_{T} [GeV]" --datacard="btag" \
-  --background_scheme="et_default" --extra_pad=1.3
+  --background_scheme="et_default" --extra_pad=0.3
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="btag" --var="bpt_1(20,0,200)" \
   --x_axis_label="Leading b-tagged jet p_{T} [GeV]" --datacard="btag" $MT_BTAG_SHIFT \
-  --background_scheme="mt_with_zmm" --extra_pad=1.3
+  --background_scheme="mt_with_zmm" --extra_pad=0.3
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="btag" --var="bpt_1(20,0,200)" $EM_BTAG_SHIFT \
   --x_axis_label="Leading b-tagged jet p_{T} [GeV]" --datacard="btag" \
-  --background_scheme="em_default" --extra_pad=1.3
+  --background_scheme="em_default" --extra_pad=0.3
 
 #### beta_1
 BETA_BINS="beta_1(10,-3,3)"
@@ -572,17 +572,17 @@ then
   BETA_BINS="beta_1(15,-3,3)"
 fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
-  --method=8 --cat="btag" --var=$BETA_BINS --extra_pad=2.0 $ET_BTAG_SHIFT \
+  --method=8 --cat="btag" --var=$BETA_BINS --extra_pad=0.3 $ET_BTAG_SHIFT \
   --x_axis_label="Leading b-tagged jet #eta" --datacard="btag" \
   --background_scheme="et_default"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
-  --method=8 --cat="btag" --var=$BETA_BINS --extra_pad=2.0 \
+  --method=8 --cat="btag" --var=$BETA_BINS --extra_pad=0.3 \
   --x_axis_label="Leading b-tagged jet #eta" --datacard="btag" $MT_BTAG_SHIFT \
   --background_scheme="mt_with_zmm"
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
-  --method=8 --cat="btag" --var=$BETA_BINS --extra_pad=2.0 \
+  --method=8 --cat="btag" --var=$BETA_BINS --extra_pad=0.3 \
   --x_axis_label="Leading b-tagged jet #eta" --datacard="btag" $EM_BTAG_SHIFT \
   --background_scheme="em_default"
 
@@ -591,34 +591,34 @@ fi
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="pt_2>30. && n_jets<=1 && n_prebjets>=1" --var="bcsv_1(25,0,1)" \
   --x_axis_label="CSV discriminator" --datacard="prebtag"  $ET_BTAG_SHIFT \
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="pt_2>30. && n_jets<=1 && n_prebjets>=1" --var="bcsv_1(25,0,1)" \
   --x_axis_label="CSV discriminator" --datacard="prebtag"  $MT_BTAG_SHIFT \
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="pt_2>30. && n_jets<=1 && n_prebjets>=1" --var="bcsv_1(25,0,1)" \
   --x_axis_label="CSV discriminator" --datacard="prebtag"  $EM_BTAG_SHIFT \
-  --background_scheme="em_default" --extra_pad=1.2
+  --background_scheme="em_default" --extra_pad=0.2
 
 #### mjj
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=et --set_alias="sel:mt_1<30." \
   --method=8 --cat="twojet" --var="mjj(20,0,1000)" $ET_2JET_SHIFT \
   --x_axis_label="M_{jj} [GeV]" --datacard="twojet" \
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="twojet" --var="mjj(20,0,1000)" $MT_2JET_SHIFT \
   --x_axis_label="M_{jj} [GeV]" --datacard="twojet" \
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="twojet" --var="mjj(20,0,1000)" $EM_2JET_SHIFT \
   --x_axis_label="M_{jj} [GeV]" --datacard="twojet" \
-  --background_scheme="em_default" --extra_pad=1.2
+  --background_scheme="em_default" --extra_pad=0.2
 
 #### jdeta
 
@@ -626,16 +626,16 @@ fi
   --method=8 --cat="twojet" --var="jdeta(20,0,10)" $ET_2JET_SHIFT \
   --x_axis_label="#Delta#eta_{jj}" \
   --datacard="twojet" \
-  --background_scheme="et_default" --extra_pad=1.2
+  --background_scheme="et_default" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=mt --set_alias="sel:mt_1<30." \
   --method=8 --cat="twojet" --var="jdeta(20,0,10)" $MT_2JET_SHIFT \
   --x_axis_label="#Delta#eta_{jj}" \
   --datacard="twojet" \
-  --background_scheme="mt_with_zmm" --extra_pad=1.2
+  --background_scheme="mt_with_zmm" --extra_pad=0.2
 
 ./bin/HiggsTauTauPlot4 --cfg=scripts/new_plot_"$ANA"_"$YEAR".cfg --channel=em --set_alias="sel:em_gf_mva>-0.5" \
   --method=8 --cat="twojet" --var="jdeta(20,0,10)" $EM_2JET_SHIFT \
   --x_axis_label="#Delta#eta_{jj}" \
   --datacard="twojet" \
-  --background_scheme="em_default" --extra_pad=1.2
+  --background_scheme="em_default" --extra_pad=0.2

--- a/Analysis/HiggsTauTau/src/HTTAnalysisTools.cc
+++ b/Analysis/HiggsTauTau/src/HTTAnalysisTools.cc
@@ -441,7 +441,7 @@ namespace ic {
     if (verbosity_) std::cout << "[HTTAnalysis::GenerateZTT] --------------------------------------------------------\n";
     //For H->hh analysis, the inclusive ZTT yield should be taken from events with tau pt down to 30 GeV, for consistency for the run 1 analysis, while the SM and MSSM analyses define inclusive as pt_2>30.
     Value ztt_norm;
-    if(method == 14 || method == 15 || method == 16 || method == 20 || method == 21 || method == 24 || method == 27) {
+    if(method == 14 || method == 15 || method == 16 || method == 20 || method == 21 || method == 24 || method == 27 || method == 28) {
         ztt_norm = this->GetRateViaRefEfficiency(this->ResolveAlias("ZTT_Eff_Sample"), "DYJetsToTauTau"+dy_soup_, "os", this->ResolveAlias("inclusivelowpt"), sel, cat, wt);
     } else {    
         ztt_norm = this->GetRateViaRefEfficiency(this->ResolveAlias("ZTT_Eff_Sample"), "DYJetsToTauTau"+dy_soup_, "os", this->ResolveAlias("inclusive"), sel, cat, wt);
@@ -700,7 +700,7 @@ namespace ic {
           << qcd_norm.first << "), setting to " << default_rate << " and maintaining error" << std::endl;
         qcd_norm.first = default_rate;
       }
-      if (method == 0 || method == 8 || method == 11 || method == 20) {
+      if (method == 0 || method == 8 || method == 28 || method == 11 || method == 20) {
         qcd_hist = this->GetShapeViaQCDMethod(var, "Data", qcd_sdb_sel, qcd_cat, qcd_sub_samples, wt, {
           {"WJetsToLNuSoup", [&]()->HTTAnalysis::Value {
             return w_ss_norm;} 

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -440,6 +440,7 @@ namespace ic {
     n_jets_ = jets.size();
     n_lowpt_jets_ = lowpt_jets.size();
     n_bjets_ = bjets.size();
+    n_prebjets_ = prebjets.size();
     n_jets_csv_ = jets_csv.size();
     n_loose_bjets_ = loose_bjets.size();
 

--- a/Analysis/HiggsTauTau/src/HTTPlotTools.cc
+++ b/Analysis/HiggsTauTau/src/HTTPlotTools.cc
@@ -347,6 +347,7 @@ namespace ic {
       h[1]->GetYaxis()->SetTitleOffset(2.0);
       pads[0]->cd();
       h[0]->GetYaxis()->SetTitleOffset(2.0);
+      pads[1]->SetGrid(0,1);
       //it complains if the minimum is set to 0 and you try to set log y scale
       if(log_y_) h[0]->SetMinimum(0.1);
       if(custom_y_axis_min_) h[0]->SetMinimum(y_axis_min_);
@@ -381,14 +382,11 @@ namespace ic {
     }
     pads[0]->cd();
    
-    
     // Setup legend
     TLegend *legend = PositionedLegend(0.40, 0.30, 3, 0.03);
     legend->SetTextFont(42);
-    FixBoxPadding(pads[0], legend, 0.05);
     HTTPlot::SetDataStyle(data_hist);    
     legend->AddEntry(data_hist, "Observed", "ple");
-    
     
     std::string bkr_list_for_ratio = "";
     // Produce stack from background components
@@ -416,7 +414,7 @@ namespace ic {
       }
     }
     //Loop again in opposite direction to fill the legend (looks better that way)
-    for (unsigned i = bkg_scheme.size()-1; i > 0; --i) {
+    for (int i = bkg_scheme.size()-1; i>=0; --i) {
         TH1PlotElement ele2 = bkg_elements[i];
         legend->AddEntry(ele2.hist_ptr(), ele2.legend_text().c_str(), "f");
     }
@@ -448,7 +446,7 @@ namespace ic {
     
     canv->Update();
    
-    //Uncertainty band - not sure if all of this is needed, check later
+    //Uncertainty band
     TH1F error_band;
     TH1F bkg_total;
     TH1PlotElement err_element;
@@ -509,7 +507,7 @@ namespace ic {
 
     //Setup ratio plots
     TH1F *ratio = reinterpret_cast<TH1F*>(MakeRatioHist(data_hist, bkg_element.hist_ptr(), true, false));
-    TH1F *err_ratio;
+    TH1F *err_ratio = NULL;
     if(draw_error_band_) err_ratio = reinterpret_cast<TH1F*>(MakeRatioHist(err_element.hist_ptr(), err_element.hist_ptr(), true, false));
 
     if (draw_ratio_) {
@@ -532,6 +530,7 @@ namespace ic {
     FixTopRange(pads[0], GetPadYMax(pads[0]), extra_pad_>0 ? extra_pad_ : 0.15);
     DrawCMSLogo(pads[0], cms_label_, cms_extra_, 11, 0.045, 0.035, 1.2);
     DrawTitle(pads[0], lumi_label_, 3);
+    FixBoxPadding(pads[0], legend, 0.05);
     legend->Draw();
     FixOverlay();
     canv->Update();

--- a/Analysis/HiggsTauTau/src/HTTPlotTools.cc
+++ b/Analysis/HiggsTauTau/src/HTTPlotTools.cc
@@ -421,7 +421,6 @@ namespace ic {
     
     //Draw backgrounds and data
     thstack.Draw("HISTSAME");
-    data_hist->Draw("pesame");
     canv->Update();
     
     std::vector<PlotSigComponent> sig_scheme = sig_schemes_[signal_scheme_];
@@ -516,6 +515,8 @@ namespace ic {
       ratio->Draw("pe0same");
     }
     pads[0]->cd();
+    //Finally draw the data
+    data_hist->Draw("pesame");
     
     //Add any text elements - for now using ic::TextElement - could definitely change this to use DrawTitle function or similar
     TLatex *title_latex = new TLatex();

--- a/Analysis/HiggsTauTau/src/HTTPlotTools.cc
+++ b/Analysis/HiggsTauTau/src/HTTPlotTools.cc
@@ -160,8 +160,9 @@ namespace ic {
       ((prefix+"signal_scheme").c_str(),        po::value<std::string>(&signal_scheme_)->default_value(""))
       ((prefix+"draw_signal_mass").c_str(),     po::value<std::string>(&draw_signal_mass_)->default_value(""))
       ((prefix+"draw_signal_tanb").c_str(),     po::value<std::string>(&draw_signal_tanb_)->default_value(""))
-      ((prefix+"title_left").c_str(),           po::value<std::string>(&title_left_)->default_value(""))
-      ((prefix+"title_right").c_str(),          po::value<std::string>(&title_right_)->default_value(""))
+      ((prefix+"cms_label").c_str(),            po::value<std::string>(&cms_label_)->default_value("CMS"))
+      ((prefix+"cms_extra").c_str(),            po::value<std::string>(&cms_extra_)->default_value("Preliminary"))
+      ((prefix+"lumi_label").c_str(),            po::value<std::string>(&lumi_label_)->default_value("19.7 fb^{-1} at 8 TeV"))
       ((prefix+"signal_scale").c_str(),         po::value<unsigned>(&signal_scale_)->default_value(1))
       ((prefix+"log_y").c_str(),                po::value<bool>(&log_y_)->default_value(false))
       ((prefix+"draw_ratio").c_str(),           po::value<bool>(&draw_ratio_)->default_value(false))
@@ -484,17 +485,22 @@ namespace ic {
     if (draw_ratio_) {
       pads[1]->cd();
       if(draw_error_band_) err_ratio->Draw("e2same");
-      //ratio->Draw("e1samex0");
       ratio->Draw("pe0same");
     }
     pads[0]->cd();
+    
+    //Add any text elements - for now using ic::TextElement - could definitely change this to use DrawTitle function or similar
+    TLatex *title_latex = new TLatex();
+    title_latex->SetNDC();
+    for (unsigned te = 0; te < text_.size(); ++te) {
+      title_latex->SetTextSize(text_[te].size());
+      title_latex->SetTextAlign(11);
+      title_latex->DrawLatex(text_[te].x_pos(), text_[te].y_pos(), text_[te].text().c_str());
+    } 
 
     FixTopRange(pads[0], GetPadYMax(pads[0]), extra_pad_>0 ? extra_pad_ : 0.15);
-    DrawCMSLogo(pads[0], "CMS", "Preliminary", 11, 0.045, 0.035, 1.2);
-    DrawTitle(pads[0], "19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)", 3);
-    //DrawTitle(pads[0], title_left_, 0);
-    //DrawTitle(pads[0], title_right_, 1);
-    //for (auto & ele : text_) plot.AddTextElement(ele);
+    DrawCMSLogo(pads[0], cms_label_, cms_extra_, 11, 0.045, 0.035, 1.2);
+    DrawTitle(pads[0], lumi_label_, 3);
     legend->Draw();
     FixOverlay();
     canv->Update();

--- a/Analysis/HiggsTauTau/src/HTTPlotTools.cc
+++ b/Analysis/HiggsTauTau/src/HTTPlotTools.cc
@@ -343,10 +343,10 @@ namespace ic {
         StandardAxes(h[1]->GetXaxis(), h[0]->GetYaxis(), x_axis_label_, units);
       }
       h[1]->GetYaxis()->SetNdivisions(4);
-      h[1]->GetXaxis()->SetTitleOffset(1.1);
-      h[1]->GetYaxis()->SetTitleOffset(1.8);
+      h[1]->GetXaxis()->SetTitleOffset(1.2);
+      h[1]->GetYaxis()->SetTitleOffset(2.0);
       pads[0]->cd();
-      h[0]->GetYaxis()->SetTitleOffset(1.8);
+      h[0]->GetYaxis()->SetTitleOffset(2.0);
       //it complains if the minimum is set to 0 and you try to set log y scale
       if(log_y_) h[0]->SetMinimum(0.1);
       if(custom_y_axis_min_) h[0]->SetMinimum(y_axis_min_);
@@ -365,8 +365,8 @@ namespace ic {
       } else {      
         StandardAxes(h[0]->GetXaxis(), h[0]->GetYaxis(), x_axis_label_, units);
       }
-      h[0]->GetXaxis()->SetTitleOffset(1.1);
-      h[0]->GetYaxis()->SetTitleOffset(1.8);
+      h[0]->GetXaxis()->SetTitleOffset(1.2);
+      h[0]->GetYaxis()->SetTitleOffset(2.0);
       if(log_y_) h[0]->SetMinimum(0.1);
       if(custom_y_axis_min_) h[0]->SetMinimum(y_axis_min_);
       if (x_axis_bin_labels_ != "") {
@@ -509,7 +509,8 @@ namespace ic {
 
     //Setup ratio plots
     TH1F *ratio = reinterpret_cast<TH1F*>(MakeRatioHist(data_hist, bkg_element.hist_ptr(), true, false));
-    TH1F *err_ratio = reinterpret_cast<TH1F*>(MakeRatioHist(err_element.hist_ptr(), err_element.hist_ptr(), true, false));
+    TH1F *err_ratio;
+    if(draw_error_band_) err_ratio = reinterpret_cast<TH1F*>(MakeRatioHist(err_element.hist_ptr(), err_element.hist_ptr(), true, false));
 
     if (draw_ratio_) {
       pads[1]->cd();

--- a/Analysis/HiggsTauTau/src/HTTPlotTools.cc
+++ b/Analysis/HiggsTauTau/src/HTTPlotTools.cc
@@ -11,6 +11,8 @@
 #include "UserCode/ICHiggsTauTau/Analysis/Utilities/interface/SimpleParamParser.h"
 #include "UserCode/ICHiggsTauTau/Analysis/Utilities/interface/FnRootTools.h"
 #include "UserCode/ICHiggsTauTau/Analysis/HiggsTauTau/interface/HTTConfig.h"
+#include "UserCode/ICHiggsTauTau/Analysis/Core/interface/Plotting.h"
+#include "UserCode/ICHiggsTauTau/Analysis/Core/interface/Plotting_Style.h"
 #include "TPad.h"
 #include "TROOT.h"
 #include "TColor.h"
@@ -107,119 +109,35 @@ namespace ic {
       PlotBkgComponent("ztt2","Z#rightarrow#tau#tau   1 #pi^{#pm} + photons"    ,{"ZTT-1P1PZ"}  ,kOrange - 0),
       PlotBkgComponent("ztt3","Z#rightarrow#tau#tau   3 #pi^{#pm}"             ,{"ZTT-3P"}     ,17)
     };
-    /*
-    bkg_schemes_["all"] = {
-      PlotBkgComponent("qcd","QCD"                  ,{"QCD","Fakes"}      , kMagenta-10),
-      PlotBkgComponent("top","t#bar{t}"             ,{"TT","ttbar"}       , kBlue   - 8),
-      PlotBkgComponent("ewk","electroweak"          ,{"W","VV","EWK"}     , kRed    + 2),
-      PlotBkgComponent("zll","Z#rightarrowll"       ,{"ZL","ZJ","ZLL"}    , kAzure  + 2),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau" ,{"ZTT","Ztt"}        , kOrange - 4)
-    };
-    bkg_schemes_["et_default"] = {
-      PlotBkgComponent("qcd","QCD"                  ,{"QCD"}      , kMagenta-10),
-      PlotBkgComponent("top","t#bar{t}"             ,{"TT"}       , kBlue   - 8),
-      PlotBkgComponent("ewk","electroweak"          ,{"W","VV"}   , kRed    + 2),
-      PlotBkgComponent("zll","Z#rightarrowee"       ,{"ZL","ZJ"}  , kAzure  + 2),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau" ,{"ZTT"}      , kOrange - 4)
-    };
-    bkg_schemes_["et_zll"] = {
-      PlotBkgComponent("qcd","QCD"                  ,{"QCD"}      , kMagenta-10),
-      PlotBkgComponent("top","t#bar{t}"             ,{"TT"}       , kBlue   - 8),
-      PlotBkgComponent("ewk","electroweak"          ,{"W","VV"}   , kRed    + 2),
-      PlotBkgComponent("zll","Z#rightarrowee"       ,{"ZLL"}      , kAzure  + 2),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau" ,{"ZTT"}      , kOrange - 4)
-    };
-    bkg_schemes_["et_with_zj"] = {
-      PlotBkgComponent("qcd","QCD"                      ,{"QCD"}      , kMagenta-10),
-      PlotBkgComponent("top","t#bar{t}"                 ,{"TT"}       , kBlue   - 8),
-      PlotBkgComponent("ewk","electroweak"              ,{"W","VV"}   , kRed    + 2),
-      PlotBkgComponent("zl","Z#rightarrowee (lepton)"   ,{"ZL"}       , kAzure  + 2),
-      PlotBkgComponent("zj","Z#rightarrowee (jet)"      ,{"ZJ"}       , kGreen  + 2),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau"     ,{"ZTT"}      , kOrange - 4)
-    };
-    bkg_schemes_["mt_default"] = {
-      PlotBkgComponent("qcd","QCD"                  ,{"QCD"}              ,kMagenta-10),
-      PlotBkgComponent("top","t#bar{t}"             ,{"TT"}               ,kBlue   - 8),
-      PlotBkgComponent("ewk","electroweak"          ,{"W","VV","ZL","ZJ"} ,kRed    + 2),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau" ,{"ZTT"}              ,kOrange - 4)
-    };
-    bkg_schemes_["em_default"] = {
-      PlotBkgComponent("qcd","fakes"                ,{"Fakes"}            ,kMagenta-10),
-      PlotBkgComponent("ewk","electroweak"          ,{"EWK"}              ,kRed    + 2),
-      PlotBkgComponent("top","t#bar{t}"             ,{"ttbar"}            ,kBlue   - 8),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau" ,{"Ztt"}              ,kOrange - 4)
-    };
-    bkg_schemes_["mt_with_zmm"] = {
-      PlotBkgComponent("qcd","QCD",                   {"QCD"},      TColor::GetColor(250,202,255)),
-      PlotBkgComponent("top","t#bar{t}",              {"TT"},       TColor::GetColor(155,152,204)),
-      PlotBkgComponent("ewk","electroweak",           {"W","VV"},   TColor::GetColor(222,90,106)),
-      PlotBkgComponent("zll","Z#rightarrow#mu#mu",    {"ZL","ZJ"},  TColor::GetColor(100,182,232)),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau",  {"ZTT"} ,     TColor::GetColor(248,206,104))
-    };
-    bkg_schemes_["mt_with_zj"] = {
-      PlotBkgComponent("qcd","QCD",{"QCD"},kMagenta-10),
-      PlotBkgComponent("top","t#bar{t}",{"TT"},kBlue   - 8),
-      PlotBkgComponent("ewk","electroweak",{"W","VV"},kRed    + 2),
-      PlotBkgComponent("zl","Z#rightarrow#mu#mu (lepton)",{"ZL"},kAzure  + 2),
-      PlotBkgComponent("zj","Z#rightarrow#mu#mu (jet)",{"ZJ"},kGreen  + 2),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau",{"ZTT"},kOrange - 4)
-    };
-    bkg_schemes_["mt_with_zmm_zll"] = {
-      PlotBkgComponent("qcd","QCD",{"QCD"},kMagenta-10),
-      PlotBkgComponent("top","t#bar{t}",{"TT"},kBlue   - 8),
-      PlotBkgComponent("ewk","electroweak",{"W","VV"},kRed    + 2),
-      PlotBkgComponent("zll","Z#rightarrow#mu#mu",{"ZLL"},kAzure  + 2),
-      PlotBkgComponent("ztt","Z#rightarrow#tau#tau",{"ZTT"},kOrange - 4)
-    };
-    bkg_schemes_["tau_modes"] = {
-      PlotBkgComponent("qcd","QCD"            ,{"QCD"}                ,kMagenta-10),
-      PlotBkgComponent("top","t#bar{t}"       ,{"TT"}                 ,kBlue   - 8),
-      PlotBkgComponent("ewk","electroweak"    ,{"W","VV"}             ,kRed    + 2),
-      PlotBkgComponent("zll","Z#rightarrow#mu#mu", {"ZL","ZJ"}        , kAzure  + 2),
-      PlotBkgComponent("ztt1","Z#rightarrow#tau#tau (1 #pi^{#pm} no photons)"   ,{"ZTT-1P0PZ"}  ,kOrange + 2),
-      PlotBkgComponent("ztt2","Z#rightarrow#tau#tau (1 #pi^{#pm} + photons)"    ,{"ZTT-1P1PZ"}  ,kOrange - 0),
-      PlotBkgComponent("ztt3","Z#rightarrow#tau#tau (3 #pi^{#pm}) "             ,{"ZTT-3P"}     ,17)
-    };
-*/
   }
-
-  void HTTPlot::SetMCStackStyle(ic::TH1PlotElement & ele, unsigned color) {
-    ele.set_fill_color(color);
-    ele.set_fill_style(1001);
-    ele.set_draw_fill(true);
-    ele.set_draw_marker(false);
-    ele.set_draw_line(false);
-    ele.set_line_width(2);
-    ele.set_draw_stat_error_y(false);
-    ele.set_in_stack(true);
+  void HTTPlot::SetMCStackStyle(TH1* hist_ptr, unsigned color) {
+    hist_ptr->SetFillColor(color);
+    hist_ptr->SetFillStyle(1001);
+    hist_ptr->SetLineColor(1);
+    hist_ptr->SetLineStyle(1);
+    hist_ptr->SetLineWidth(2);
+    hist_ptr->SetMarkerColor(1);
+    hist_ptr->SetMarkerStyle(21);
+    hist_ptr->SetMarkerSize(0.8);
+    hist_ptr->SetStats(false);
     return;
   }
-  void HTTPlot::SetSignalStyle(ic::TH1PlotElement & ele, unsigned color) {
-    ele.set_fill_style(1001);
-    ele.set_draw_fill(true);
-    ele.set_draw_marker(false);
-    ele.set_draw_line(true);
-    ele.set_draw_stat_error_y(false);
-    ele.set_in_stack(true);
-    ele.set_draw_fill_in_legend(false);
-    ele.set_line_style(11);
-    ele.set_fill_color(0);
-    ele.set_line_color(color);
-    ele.set_line_width(2);
+  void HTTPlot::SetSignalStyle(TH1* hist_ptr, unsigned color) {
+    hist_ptr->SetFillStyle(1001);
+    hist_ptr->SetLineStyle(9);
+    hist_ptr->SetFillColor(0);
+    hist_ptr->SetLineColor(color);
+    hist_ptr->SetLineWidth(3);
     return;
   }
-  void HTTPlot::SetDataStyle(ic::TH1PlotElement & ele) {
-    ele.set_marker_color(1);
-    ele.set_line_color(1);
-    ele.set_fill_color(1);
-    ele.set_fill_style(0);
-    ele.set_draw_fill(false);
-    ele.set_line_width(2);
-    ele.set_draw_marker(true);
-    ele.set_draw_line(true);
-    ele.set_marker_style(20);
-    ele.set_draw_stat_error_y(true);
-    ele.set_marker_size(1.1);
+  void HTTPlot::SetDataStyle(TH1* hist_ptr) {
+    hist_ptr->SetMarkerColor(1);
+    hist_ptr->SetLineColor(1);
+    hist_ptr->SetFillColor(1);
+    hist_ptr->SetFillStyle(0);
+    hist_ptr->SetLineWidth(2);
+    hist_ptr->SetMarkerStyle(20);
+    hist_ptr->SetMarkerSize(1.1);
     return;
   }
 
@@ -387,40 +305,13 @@ namespace ic {
         {"ggH_hww","qqH_hww"}, TColor::GetColor(0,18,255), false)
     };
 
-    ic::Plot plot;
-    if (use_htt_style_) plot.use_htt_style = true;
-
-    plot.output_filename = plot_name_+".pdf";
-    if (log_y_) {
-      plot.output_filename = plot_name_+"_log.pdf";
-      plot.y_axis_log = true;
-    }
-    plot.x_bin_labels_ = x_axis_bin_labels_;
-
-    plot.extra_pad = extra_pad_;
-    plot.custom_x_axis_range = custom_x_axis_range_;
-    if (custom_x_axis_range_){
-      plot.x_axis_min = x_axis_min_;
-      plot.x_axis_max = x_axis_max_;
-    }
-    if (custom_y_axis_min_) {
-      plot.y_axis_min = y_axis_min_;
-    }
-    // if (mssm_mode == 1) plot.legend_height = 0.045;
-    plot.x_axis_title = x_axis_label_;
-    plot.y_axis_title = y_axis_label_;
-
-    plot.draw_ratio_hist = draw_ratio_;
-
-    plot.title_left = title_left_;
-    plot.title_right = title_right_;
-
-    // should check if data actually exists: we might want to make a plot
-    // where it doesn't
-    TH1PlotElement data_plot("data", &hmap["data_obs"].first, "Observed");
-    if (norm_bins_) data_plot.hist_ptr()->Scale(1.0, "width");
+    ModTDRStyle();
+    THStack thstack("stack","stack");
+    
+    // First collect the data histogram and blind it if necessary
+    TH1F *data_hist = &hmap["data_obs"].first;
+    if (norm_bins_) data_hist->Scale(1.0, "width");
     if (blind_) {
-      TH1F *data_hist = &hmap["data_obs"].first;
       for (int j = 0; j < data_hist->GetNbinsX(); ++j) {
         double low_edge = data_hist->GetBinLowEdge(j+1);
         double high_edge = data_hist->GetBinWidth(j+1)+data_hist->GetBinLowEdge(j+1);
@@ -430,14 +321,44 @@ namespace ic {
         }
       }
     }
-
-    // should checkt the bakground scheme actually exists
+    
+    // Setup canvas and 1/2 TPads as necessary
+    TCanvas* canv = new TCanvas("c1", "c1");
+    canv->cd();
+  
+    std::vector<TPad*> pads =
+        draw_ratio_ ? TwoPadSplit(0.29, 0.00, 0.00) : OnePad();
+   
+    // Create axes based on data hist and possible user specified axis range
+    std::vector<TH1*> h = CreateAxisHists(2, data_hist, custom_x_axis_range_ ? x_axis_min_ : data_hist->GetXaxis()->GetXmin(), custom_x_axis_range_ ? x_axis_max_ : data_hist->GetXaxis()->GetXmax());
+    h[0]->Draw("axis");
+    
+    // Set second axis when necessary
+    if (draw_ratio_) {
+      pads[0]->cd();
+      pads[1]->cd();
+      h[1]->Draw("axis");
+      h[1]->GetXaxis()->SetTitleOffset(1.0);
+      SetupTwoPadSplitAsRatio(pads, "Obs/Exp", true, 0.60, 1.40);
+      StandardAxes(h[1]->GetXaxis(), h[0]->GetYaxis(), x_axis_label_, "GeV");
+      h[1]->GetYaxis()->SetNdivisions(4);
+    } else {
+      StandardAxes(h[0]->GetXaxis(), h[0]->GetYaxis(), x_axis_label_, "GeV");
+    }
+    pads[0]->cd();    
+    
+    
+    // Setup legend
+    TLegend *legend = PositionedLegend(0.40, 0.30, 3, 0.03);
+    legend->SetTextFont(42);
+    FixBoxPadding(pads[0], legend, 0.05);
+    legend->AddEntry(data_hist, "Observed", "pe");
+    
+    
+    std::string bkr_list_for_ratio = "";
+    // Produce stack from background components
     std::vector<PlotBkgComponent> bkg_scheme = bkg_schemes_[background_scheme_];
     std::vector<TH1PlotElement> bkg_elements;
-
-    std::string bkr_list_for_ratio = "";
-
-
     for (unsigned i = 0; i < bkg_scheme.size(); ++i) {
       if (i == 0) bkr_list_for_ratio += bkg_scheme[i].name;
       if (i != 0) bkr_list_for_ratio += ("+"+bkg_scheme[i].name);
@@ -453,12 +374,32 @@ namespace ic {
         }
       }
       if (valid_element) {
-        HTTPlot::SetMCStackStyle(bkg_elements.back(), bkg_scheme[i].color);
-        if (norm_bins_) bkg_elements.back().hist_ptr()->Scale(1.0, "width");
-        plot.AddTH1PlotElement(bkg_elements.back());
+        TH1PlotElement ele = bkg_elements.back();
+        HTTPlot::SetMCStackStyle(ele.hist_ptr(), bkg_scheme[i].color);
+        if (norm_bins_) ele.hist_ptr()->Scale(1.0, "width");
+        //Special settings for the first histogram in the stack
+        /*if(i==1) {
+          if (use_htt_style_) {
+            ele.hist_ptr()->SetTitleSize  (0.055,"Y");
+            ele.hist_ptr()->SetTitleOffset(1.400,"Y");
+            if (!draw_ratio_) ele.hist_ptr()->SetTitleOffset(1.500,"Y");
+            ele.hist_ptr()->SetLabelOffset(0.010,"X");
+            ele.hist_ptr()->SetLabelSize  (0.040,"X");
+            ele.hist_ptr()->SetLabelFont  (42   ,"X");
+          }
+
+        } */       
+        thstack.Add(ele.hist_ptr(),"HIST");
+        legend->AddEntry(ele.hist_ptr(), ele.legend_text().c_str(), "f");
       }
     }
-
+    
+    //Draw backgrounds and data
+    HTTPlot::SetDataStyle(data_hist);    
+    thstack.Draw();
+    data_hist->Draw("PE1same");
+    canv->Update();
+    
     std::vector<PlotSigComponent> sig_scheme = sig_schemes_[signal_scheme_];
     std::vector<TH1PlotElement> sig_elements;
     for (unsigned i = 0; i < sig_scheme.size(); ++i) {
@@ -467,14 +408,21 @@ namespace ic {
         sig_elements.back().hist_ptr()->Add(&hmap[sig_scheme[i].plots[j]+draw_signal_mass_].first);
       }
       sig_elements.back().hist_ptr()->Scale(signal_scale_);
-      HTTPlot::SetSignalStyle(sig_elements.back(), sig_scheme[i].color);
-      if (!sig_scheme[i].in_stack) {
-        sig_elements.back().set_in_stack(false);
-        sig_elements.back().set_line_width(3);
-      }
+      HTTPlot::SetSignalStyle(sig_elements.back().hist_ptr(), sig_scheme[i].color);
       if (norm_bins_) sig_elements.back().hist_ptr()->Scale(1.0, "width");
-      plot.AddTH1PlotElement(sig_elements.back());
+      legend->AddEntry(sig_elements.back().hist_ptr(), sig_elements.back().legend_text().c_str(), "f");
+      //Draw signal
+      if(sig_scheme[i].in_stack) {
+        thstack.Add(sig_elements.back().hist_ptr(), "HIST");
+        canv->Update();
+      } else {
+        sig_elements.back().hist_ptr()->Draw("HISTsame");
+      }
     }
+    if (thstack.GetHistogram()) thstack.SetMaximum(thstack.GetMaximum()*1.1*extra_pad_);
+    canv->Update();
+   
+    //Uncertainty band - not sure if all of this is needed, check later
     TH1F error_band;
     TH1F bkg_total;
     TH1PlotElement err_element;
@@ -505,77 +453,57 @@ namespace ic {
       err_element = TH1PlotElement("error_shape", &error_band,"Bkg. uncertainty");
       bkg_element = TH1PlotElement("bkg_shape", &bkg_total,"");
 
-      err_element.set_marker_size(0);
-      err_element.set_fill_color(13);
-      err_element.set_fill_style(3013);
-      err_element.set_line_width(1);
-      err_element.set_draw_stat_error_y(true);
-      err_element.set_draw_fill(true);
-      err_element.set_draw_line(false);
-      err_element.set_draw_marker(false);
-      err_element.set_draw_options("e2");
-      bkg_element.set_marker_size(0);
-      bkg_element.set_fill_color(1);
-      bkg_element.set_fill_style(0);
-      bkg_element.set_line_width(1);
-      bkg_element.set_draw_stat_error_y(true);
-      bkg_element.set_draw_fill(true);
-      bkg_element.set_draw_line(false);
-      bkg_element.set_draw_marker(false);
-      bkg_element.set_draw_options("e2");
-      plot.AddTH1PlotElement(err_element);
-      plot.AddTH1PlotElement(bkg_element);
+      err_element.hist_ptr()->SetMarkerSize(0);
+      int new_idx = CreateTransparentColor(13, 0.5);
+      err_element.hist_ptr()->SetFillColor(new_idx);
+      err_element.hist_ptr()->SetFillStyle(3001);
+      err_element.hist_ptr()->SetLineWidth(1);
+      bkg_element.hist_ptr()->SetMarkerSize(0);
+      bkg_element.hist_ptr()->SetFillColor(1);
+      bkg_element.hist_ptr()->SetFillStyle(0);
+      bkg_element.hist_ptr()->SetLineWidth(1);
+      err_element.hist_ptr()->Draw("e2same");
+      legend->AddEntry(err_element.hist_ptr(), "bkg. uncertainty" , "F" );
+      canv->Update();
     } else {
-        bkg_total = *((TH1F*)bkg_elements[0].hist_ptr()->Clone());
-        for (unsigned i = 1; i < bkg_elements.size(); ++i) {
-          bkg_total.Add(bkg_elements[i].hist_ptr());
-        }
-        for (unsigned i = 1; i <= unsigned(bkg_total.GetNbinsX()); ++i) {
-          bkg_total.SetBinError(i, 0.0);
-        }
-        bkg_element = TH1PlotElement("bkg_shape", &bkg_total,"");
-        bkg_element.set_marker_size(0);
-        bkg_element.set_fill_color(1);
-        bkg_element.set_fill_style(0);
-        bkg_element.set_line_width(1);
-        bkg_element.set_draw_stat_error_y(true);
-        bkg_element.set_draw_fill(true);
-        bkg_element.set_draw_line(false);
-        bkg_element.set_draw_marker(false);
-        bkg_element.set_draw_options("e2");
-        plot.AddTH1PlotElement(bkg_element);
+      bkg_total = *((TH1F*)bkg_elements[0].hist_ptr()->Clone());
+      for (unsigned i = 1; i < bkg_elements.size(); ++i) {
+        bkg_total.Add(bkg_elements[i].hist_ptr());
+      }
+      for (unsigned i = 1; i <= unsigned(bkg_total.GetNbinsX()); ++i) {
+        bkg_total.SetBinError(i, 0.0);
+      }
+      bkg_element = TH1PlotElement("bkg_shape", &bkg_total,"");
+      bkg_element.hist_ptr()->SetMarkerSize(0);
+      bkg_element.hist_ptr()->SetFillColor(1);
+      bkg_element.hist_ptr()->SetFillStyle(0);
+      bkg_element.hist_ptr()->SetLineWidth(1);
     }
 
-    ic::RatioPlotElement ratio("ratio","data","bkg_shape");
-    ic::RatioPlotElement err_ratio("err_ratio","error_shape","bkg_shape");
-    if (draw_error_band_) {
-      err_ratio.set_marker_size(0);
-      err_ratio.set_fill_color(13);
-      err_ratio.set_fill_style(3013);
-      err_ratio.set_line_width(1);
-      err_ratio.set_draw_stat_error_y(true);
-      err_ratio.set_draw_fill(false);
-      err_ratio.set_draw_line(false);
-      err_ratio.set_draw_marker(false);
-      err_ratio.set_draw_options("e2");
-      plot.AddRatioPlotElement(err_ratio);
+    //Setup ratio plots
+    TH1F *ratio = reinterpret_cast<TH1F*>(MakeRatioHist(data_hist, bkg_element.hist_ptr(), true, false));
+    TH1F *err_ratio = reinterpret_cast<TH1F*>(MakeRatioHist(err_element.hist_ptr(), err_element.hist_ptr(), true, false));
+
+    if (draw_ratio_) {
+      pads[1]->cd();
+      h[1]->Draw("axis");
+      if(draw_error_band_) err_ratio->Draw("e2same");
+      ratio->Draw("esamex0");
     }
-    HTTPlot::SetRatioStyle(ratio,1);
-    ratio.set_multi_mode(true);
-    plot.ratio_y_axis_title = "Obs/Bkg";
-    plot.AddRatioPlotElement(ratio);
-    plot.custom_ratio_y_axis_range = true;
-    plot.ratio_y_axis_min = ratio_min_;
-    plot.ratio_y_axis_max = ratio_max_;
-    HTTPlot::SetDataStyle(data_plot);
-    plot.AddTH1PlotElement(data_plot);
-    plot.legend_height = 0.045;
-    if (draw_ratio_) plot.legend_height = 0.05;
-    if (draw_ratio_ && signal_scheme_ == "sm_split_vbf") plot.legend_height = 0.045;
+    pads[0]->cd();
 
-    for (auto & ele : text_) plot.AddTextElement(ele);
-
-    plot.GeneratePlot();
+    FixTopRange(pads[0], GetPadYMax(pads[0]), 0.15);
+    DrawCMSLogo(pads[0], "CMS", "Preliminary", 11, 0.045, 0.035, 1.2);
+    DrawTitle(pads[0], "19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)", 3);
+    //DrawTitle(pads[0], title_left_, 0);
+    //DrawTitle(pads[0], title_right_, 1);
+    //for (auto & ele : text_) plot.AddTextElement(ele);
+    legend->Draw();
+    FixOverlay();
+    canv->Update();
+    pads[0]->GetFrame()->Draw();
+    canv->Print((plot_name_+".pdf").c_str());
+    canv->Print((plot_name_+".png").c_str());
   }
 
   void HTTPlot::AddTextElement(ic::TextElement & ele) {

--- a/Analysis/HiggsTauTau/test/HiggsTauTauPlot4.cpp
+++ b/Analysis/HiggsTauTau/test/HiggsTauTauPlot4.cpp
@@ -1082,8 +1082,10 @@ int main(int argc, char* argv[]){
 	if (auto_titles) {
 		double fb_lumi = ana.GetLumi() / 1000.;
 		string com = is_2012 ? "8" : "7";
-		plot.set_title_left((boost::format("CMS, %.1f fb^{-1} at %s TeV") % fb_lumi % com).str());
-    std::string channel_fmt = ""; 
+        plot.set_lumi_label((boost::format("%.1f fb^{-1} at %s TeV") % fb_lumi % com).str());
+        plot.set_cms_label("CMS");
+        plot.set_cms_extra("");
+        std::string channel_fmt = ""; 
 		//if (channel_str == "et") 		plot.set_title_right("e#tau_{h}");
 		//if (channel_str == "mt") 		plot.set_title_right("#mu#tau_{h}");
 		//if (channel_str == "mtmet") plot.set_title_right("#mu_{soft}#tau_{h}");
@@ -1092,7 +1094,8 @@ int main(int argc, char* argv[]){
 		if (channel_str == "mt") 		channel_fmt = "#mu#tau_{h}";
 		if (channel_str == "mtmet") channel_fmt = "#mu_{soft}#tau_{h}";
 		if (channel_str == "em") 		channel_fmt = "e#mu";
-    ic::TextElement text(channel_fmt,0.08,0.21,0.82);
+    ic::TextElement text(channel_fmt,0.05,0.16,0.96);
+
     //ic::TextElement text2("#splitline{Same-sign}{region}",0.05,0.65,0.5);
     plot.AddTextElement(text);
     //plot.AddTextElement(text2);


### PR DESCRIPTION
@ajgilbert @adewit I think this is about complete now. Contains:
 
- Removed all dependence on ic::Plot from HTTPlotTools and made the code standalone using only the new functions in Plotting.h. The code still uses ic::TextElements and ic::TH1PlotElements just because in places they make the code a little neater, but these are not really needed anymore either and could be removed if we wanted pure standalone root plotting code which could be duplicated outside the package.  

A set of example plots produced by the new code can be found here:
https://www.dropbox.com/sh/fs11t27sbfptmjn/AABLsoD3NOdu8-IgH4fxJhiKa?dl=0
There is a slightly random assortment of with and without log scale, ratios, signal, "Preliminary" label etc to try out all possibilities. I think it looks pretty nice and closer to the CMS recommendations. Of course we can iterate on style, but now all iterations can be made from within HTTPlotTools. 

- A couple of bug fixes related to when I reintroduced the H->hh code a few weeks ago. They were quite subtle things not picked up by my checks of running datacards with old and new code, but turned up when looking at the control plots.

Comments welcome. 