### PR TITLE
CLASS_MEMBER macro: safer to leave scope as private

### DIFF
--- a/Analysis/Core/interface/ModuleBase.h
+++ b/Analysis/Core/interface/ModuleBase.h
@@ -9,10 +9,11 @@
 namespace ic { class TreeEvent; }
 
 #define CLASS_MEMBER(classn,type,name)                                                \
-    private:                                                                \
-      type name##_;                                                         \
-    public:                                                                 \
-      virtual classn & set_##name(type const& name) {name##_ = name; return *this; }
+    private:                                                                          \
+      type name##_;                                                                   \
+    public:                                                                           \
+      virtual classn & set_##name(type const& name) {name##_ = name; return *this; }  \
+    private:
 
 namespace ic {
 


### PR DESCRIPTION
fixes #1 (finally)