### PR TITLE
New sync ntuple producer

### DIFF
--- a/Analysis/HiggsTauTau/interface/HTTCategories.h
+++ b/Analysis/HiggsTauTau/interface/HTTCategories.h
@@ -23,13 +23,24 @@ class HTTCategories : public ModuleBase {
   CLASS_MEMBER(HTTCategories, ic::strategy, strategy)
   CLASS_MEMBER(HTTCategories, bool, write_tree)
   CLASS_MEMBER(HTTCategories, bool, bjet_regression)
+  CLASS_MEMBER(HTTCategories, bool, make_sync_ntuple)
+  CLASS_MEMBER(HTTCategories, bool, is_embedded)
+  CLASS_MEMBER(HTTCategories, std::string, sync_output_name)
   CLASS_MEMBER(HTTCategories, int, kinfit_mode )
   CLASS_MEMBER(HTTCategories, fwlite::TFileService*, fs)
  
   TTree *outtree_;
+  TTree *synctree_;
+  TFile *lOFile;
 
   // Event Properties
   double wt_;
+  int run_;
+  int event_;
+  int lumi_;
+  double rho_;
+  double mc_weight_;
+  double pu_weight_;
   double wt_ggh_pt_up_;
   double wt_ggh_pt_down_;
   double wt_tau_fake_up_;
@@ -38,13 +49,27 @@ class HTTCategories : public ModuleBase {
   double wt_tquark_down_;
   double wt_tau_id_up_;
   double wt_tau_id_down_;
+  double trigweight_1_;
+  double trigweight_2_;
+  double idweight_1_;
+  double idweight_2_;
+  double isoweight_1_;
+  double isoweight_2_;
+  double effweight_;
+  double fakeweight_;
+  double embeddedweight_;
+  double signalweight_;
   bool os_;
   unsigned n_vtx_;
+  unsigned n_pu_;
   double m_sv_;
   double m_vis_;
   double pt_h_;
+  double eta_h_;
+  double phi_h_;
   double pt_tt_;
   double mt_1_;
+  double mt_2_;
   double mt_ll_;
   double pzeta_;
   double pzetavis_;
@@ -53,16 +78,37 @@ class HTTCategories : public ModuleBase {
   double emu_csv_;
   double emu_dxy_1_;
   double emu_dxy_2_;
+  double d0_1_;
+  double d0_2_;
+  double dz_1_;
+  double dz_2_;
   double pt_1_;
   double pt_2_;
   double eta_1_;
   double eta_2_;
+  double phi_1_;
+  double phi_2_;
+  int q_1_;
+  int q_2_;
   double iso_1_;
   double iso_2_;
   double z_2_;
+  double m_1_;
   double m_2_;
+  double mva_1_;
+  double mva_2_;
   double met_;
   double met_phi_;
+  double pfmet_;
+  double pfmet_phi_;
+  double metCov00_;
+  double metCov01_;
+  double metCov10_;
+  double metCov11_;
+  double pfmetCov00_;
+  double pfmetCov01_;
+  double pfmetCov10_;
+  double pfmetCov11_;
 
   int    tau_decay_mode_;
 
@@ -75,8 +121,11 @@ class HTTCategories : public ModuleBase {
   double jpt_2_;     // Defined if n_jets >= 2
   double jeta_1_;    // Defined if n_jets >= 1
   double jeta_2_;    // Defined if n_jets >= 2
+  double jphi_1_;    // Defined if n_jets >= 1
+  double jphi_2_;    // Defined if n_jets >= 2
   double bpt_1_;     // Defined if n_bjets >= 1
   double beta_1_;    // Defined if n_bjets >= 1
+  double bphi_1_;    // Defined if n_bjets >= 1
   double bcsv_1_; 
   double jet_csvpt_1_;     // Defined if n_jets >= 1
   double jet_csvEt_1_;     // Defined if n_jets >= 1

--- a/Analysis/HiggsTauTau/interface/HTTCategories.h
+++ b/Analysis/HiggsTauTau/interface/HTTCategories.h
@@ -138,6 +138,16 @@ class HTTCategories : public ModuleBase {
   branch_var jeta_2_;    // Defined if n_jets >= 2
   float jphi_1_;    // Defined if n_jets >= 1
   float jphi_2_;    // Defined if n_jets >= 2
+  float jptraw_1_; 
+  float jptraw_2_; 
+  float jptunc_1_; 
+  float jptunc_2_; 
+  float jmva_1_; 
+  float jmva_2_; 
+  float jlrm_1_; 
+  float jlrm_2_; 
+  float jctm_1_; 
+  float jctm_2_; 
   branch_var bpt_1_;     // Defined if n_bjets >= 1
   branch_var beta_1_;    // Defined if n_bjets >= 1
   float bphi_1_;    // Defined if n_bjets >= 1

--- a/Analysis/HiggsTauTau/interface/HTTCategories.h
+++ b/Analysis/HiggsTauTau/interface/HTTCategories.h
@@ -33,14 +33,19 @@ class HTTCategories : public ModuleBase {
   TTree *synctree_;
   TFile *lOFile;
 
+  struct branch_var {
+      double var_double;  
+      float var_float;
+  };
+
   // Event Properties
-  double wt_;
+  branch_var wt_;
   int run_;
   int event_;
   int lumi_;
-  double rho_;
-  double mc_weight_;
-  double pu_weight_;
+  float rho_;
+  float mc_weight_;
+  float pu_weight_;
   double wt_ggh_pt_up_;
   double wt_ggh_pt_down_;
   double wt_tau_fake_up_;
@@ -49,89 +54,89 @@ class HTTCategories : public ModuleBase {
   double wt_tquark_down_;
   double wt_tau_id_up_;
   double wt_tau_id_down_;
-  double trigweight_1_;
-  double trigweight_2_;
-  double idweight_1_;
-  double idweight_2_;
-  double isoweight_1_;
-  double isoweight_2_;
-  double effweight_;
-  double fakeweight_;
-  double embeddedweight_;
-  double signalweight_;
+  float trigweight_1_;
+  float trigweight_2_;
+  float idweight_1_;
+  float idweight_2_;
+  float isoweight_1_;
+  float isoweight_2_;
+  float effweight_;
+  float fakeweight_;
+  float embeddedweight_;
+  float signalweight_;
   bool os_;
   unsigned n_vtx_;
   unsigned n_pu_;
-  double m_sv_;
-  double m_vis_;
-  double pt_h_;
-  double eta_h_;
-  double phi_h_;
-  double pt_tt_;
-  double mt_1_;
-  double mt_2_;
+  branch_var m_sv_;
+  branch_var m_vis_;
+  branch_var pt_h_;
+  float eta_h_;
+  float phi_h_;
+  branch_var pt_tt_;
+  branch_var mt_1_;
+  float mt_2_;
   double mt_ll_;
-  double pzeta_;
-  double pzetavis_;
-  double pzetamiss_;
+  branch_var pzeta_;
+  branch_var pzetavis_;
+  branch_var pzetamiss_;
   double emu_dphi_;
   double emu_csv_;
   double emu_dxy_1_;
   double emu_dxy_2_;
-  double d0_1_;
-  double d0_2_;
-  double dz_1_;
-  double dz_2_;
-  double pt_1_;
-  double pt_2_;
-  double eta_1_;
-  double eta_2_;
-  double phi_1_;
-  double phi_2_;
+  float d0_1_;
+  float d0_2_;
+  float dz_1_;
+  float dz_2_;
+  branch_var pt_1_;
+  branch_var pt_2_;
+  branch_var eta_1_;
+  branch_var eta_2_;
+  float phi_1_;
+  float phi_2_;
   int q_1_;
   int q_2_;
-  double iso_1_;
-  double iso_2_;
+  float iso_1_;
+  float iso_2_;
   double z_2_;
-  double m_1_;
-  double m_2_;
-  double mva_1_;
-  double mva_2_;
-  double met_;
-  double met_phi_;
-  double pfmet_;
-  double pfmet_phi_;
-  double metCov00_;
-  double metCov01_;
-  double metCov10_;
-  double metCov11_;
-  double pfmetCov00_;
-  double pfmetCov01_;
-  double pfmetCov10_;
-  double pfmetCov11_;
+  float m_1_;
+  branch_var m_2_;
+  float mva_1_;
+  float mva_2_;
+  branch_var met_;
+  branch_var met_phi_;
+  float pfmet_;
+  float pfmet_phi_;
+  float metCov00_;
+  float metCov01_;
+  float metCov10_;
+  float metCov11_;
+  float pfmetCov00_;
+  float pfmetCov01_;
+  float pfmetCov10_;
+  float pfmetCov11_;
 
-  int    tau_decay_mode_;
+  int tau_decay_mode_;
 
   unsigned n_jets_;
   unsigned n_lowpt_jets_;
   unsigned n_bjets_;
   unsigned n_loose_bjets_;
   unsigned n_jetsingap_; // Defined if n_jets >= 2
-  double jpt_1_;     // Defined if n_jets >= 1
-  double jpt_2_;     // Defined if n_jets >= 2
-  double jeta_1_;    // Defined if n_jets >= 1
-  double jeta_2_;    // Defined if n_jets >= 2
-  double jphi_1_;    // Defined if n_jets >= 1
-  double jphi_2_;    // Defined if n_jets >= 2
-  double bpt_1_;     // Defined if n_bjets >= 1
-  double beta_1_;    // Defined if n_bjets >= 1
-  double bphi_1_;    // Defined if n_bjets >= 1
+  branch_var jpt_1_;     // Defined if n_jets >= 1
+  branch_var jpt_2_;     // Defined if n_jets >= 2
+  branch_var jeta_1_;    // Defined if n_jets >= 1
+  branch_var jeta_2_;    // Defined if n_jets >= 2
+  float jphi_1_;    // Defined if n_jets >= 1
+  float jphi_2_;    // Defined if n_jets >= 2
+  branch_var bpt_1_;     // Defined if n_bjets >= 1
+  branch_var beta_1_;    // Defined if n_bjets >= 1
+  float bphi_1_;    // Defined if n_bjets >= 1
   double bcsv_1_; 
   double jet_csvpt_1_;     // Defined if n_jets >= 1
   double jet_csvEt_1_;     // Defined if n_jets >= 1
   double jet_csvpt_2_;     // Defined if n_jets >= 2
-	double jet_csvpt_bb_;
-	double jet_csv_dR_;
+  double jet_csvpt_bb_;
+  double jet_csv_dR_;
   double jet_csveta_1_;    // Defined if n_jets >= 1
   double jet_csveta_2_;    // Defined if n_jets >= 2
   double jet_csvbcsv_1_; 
@@ -139,7 +144,7 @@ class HTTCategories : public ModuleBase {
 
   int j1_dm_;
 
-  double mjj_;       // Defined if n_jets >= 2
+  branch_var mjj_;       // Defined if n_jets >= 2
   double mjj_h_;       // Defined if n_jets >= 2
   double mbb_h_;       // Defined if n_jets >= 2
   double mjj_tt_;       // Defined if n_jets >= 2
@@ -164,7 +169,7 @@ class HTTCategories : public ModuleBase {
   double m_bb_chi2_;   //Defined if n_jets >= 2
   double pull_balance_bb_; //Defined if n_jets >= 2
   int convergence_bb_; //Defined if n_jets >= 2
-  double jdeta_;     // Defined if n_jets >= 2
+  branch_var jdeta_;     // Defined if n_jets >= 2
 
   double jet_csv_mjj_;       // Defined if n_jets >= 2
   double jet_csv_deta_;     // Defined if n_jets >= 2
@@ -178,13 +183,9 @@ class HTTCategories : public ModuleBase {
   unsigned n_jets_csv_;
   unsigned n_bjets_csv_;
 
-  double l1_met_;
-  double calo_nohf_met_;
-
   double em_gf_mva_;
   double em_vbf_mva_;
 
-    // Other VBF MVA variables?
 
  public:
   HTTCategories(std::string const& name);

--- a/Analysis/HiggsTauTau/interface/HTTCategories.h
+++ b/Analysis/HiggsTauTau/interface/HTTCategories.h
@@ -22,20 +22,10 @@ class HTTCategories : public ModuleBase {
   CLASS_MEMBER(HTTCategories, ic::era, era)
   CLASS_MEMBER(HTTCategories, ic::strategy, strategy)
   CLASS_MEMBER(HTTCategories, bool, write_tree)
-  CLASS_MEMBER(HTTCategories, bool, write_plots)
-  CLASS_MEMBER(HTTCategories, bool, experimental)
   CLASS_MEMBER(HTTCategories, bool, bjet_regression)
   CLASS_MEMBER(HTTCategories, int, kinfit_mode )
   CLASS_MEMBER(HTTCategories, fwlite::TFileService*, fs)
-
-  std::map<std::string, bool> categories_;
-  std::map<std::string, bool> selections_;
-  std::map<std::string, MassPlots*> massplots_;
-  std::map<std::string, double> yields_;
-  std::map<std::string, CoreControlPlots*> controlplots_;
-  DynamicHistoSet * misc_plots_;
-  Dynamic2DHistoSet * misc_2dplots_;
-  
+ 
   TTree *outtree_;
 
   // Event Properties
@@ -156,20 +146,9 @@ class HTTCategories : public ModuleBase {
   virtual int PostAnalysis();
   virtual void PrintInfo();
 
-  bool PassesCategory(std::string const& category) const;
 
-  void InitSelection(std::string const& selection);
-  void InitCategory(std::string const& category);
-  void InitMassPlots(std::string const& category);
-  void FillMassPlots(std::string const& category);
-  void FillYields(std::string const& category);
-  void InitCoreControlPlots(std::string const& category);
-  void FillCoreControlPlots(std::string const& category);
 
-  void SetPassCategory(std::string const& category);
-  void SetPassSelection(std::string const& selection);
 
-  void Reset();
 
 
 };

--- a/Analysis/HiggsTauTau/interface/HTTCategories.h
+++ b/Analysis/HiggsTauTau/interface/HTTCategories.h
@@ -75,6 +75,9 @@ class HTTCategories : public ModuleBase {
   float embeddedweight_;
   float signalweight_;
   bool os_;
+  bool dilepton_veto_;
+  bool extraelec_veto_;
+  bool extramuon_veto_;
   unsigned n_vtx_;
   unsigned n_pu_;
   branch_var m_sv_;

--- a/Analysis/HiggsTauTau/interface/HTTCategories.h
+++ b/Analysis/HiggsTauTau/interface/HTTCategories.h
@@ -36,6 +36,16 @@ class HTTCategories : public ModuleBase {
   struct branch_var {
       double var_double;  
       float var_float;
+      branch_var& operator=(double doub){
+          var_double = doub;
+          var_float = static_cast<float>(doub);
+          return *this;
+      }
+      branch_var& operator*(double sf){
+          var_double*=sf;
+          var_float*=sf;
+          return *this;
+      }
   };
 
   // Event Properties

--- a/Analysis/HiggsTauTau/interface/HTTFilter.h
+++ b/Analysis/HiggsTauTau/interface/HTTFilter.h
@@ -1,0 +1,110 @@
+#ifndef ICHiggsTauTau_Module_HTTFilter_h
+#define ICHiggsTauTau_Module_HTTFilter_h
+
+#include "UserCode/ICHiggsTauTau/Analysis/Core/interface/TreeEvent.h"
+#include "UserCode/ICHiggsTauTau/Analysis/Core/interface/ModuleBase.h"
+#include "UserCode/ICHiggsTauTau/Analysis/Utilities/interface/FnPredicates.h"
+#include "boost/function.hpp"
+
+#include <string>
+
+namespace ic {
+
+template <class T>
+class HTTFilter : public ModuleBase {
+ private:
+  CLASS_MEMBER(HTTFilter<T>, boost::function<bool (T const*)>, predicate)
+  CLASS_MEMBER(HTTFilter<T>, std::string, input_label)
+  CLASS_MEMBER(HTTFilter<T>, unsigned, min)
+  CLASS_MEMBER(HTTFilter<T>, unsigned, max)
+	CLASS_MEMBER(HTTFilter<T>, bool, make_sync_ntuple)
+	CLASS_MEMBER(HTTFilter<T>, std::string, veto_name)
+
+ public:
+  HTTFilter(std::string const& name);
+  virtual ~HTTFilter();
+
+  virtual int PreAnalysis();
+  virtual int Execute(TreeEvent *event);
+  virtual int PostAnalysis();
+  virtual void PrintInfo();
+};
+
+template <class T>
+HTTFilter<T>::HTTFilter(std::string const& name) : ModuleBase(name) {
+  min_ = 0;
+  max_ = 9999;
+	make_sync_ntuple_ = false;
+	veto_name_ = "veto";
+}
+
+template <class T>
+HTTFilter<T>::~HTTFilter() {
+  ;
+}
+
+template <class T>
+int HTTFilter<T>::PreAnalysis() {
+  return 0;
+}
+
+template <class T>
+int HTTFilter<T>::Execute(TreeEvent *event) {
+  std::vector<T *> & vec = event->GetPtrVec<T>(input_label_);
+  ic::erase_if(vec,!boost::bind(predicate_,_1));
+	if(make_sync_ntuple_){
+	  if(vec.size() >= min_ && vec.size() <= max_){
+		  event->Add(veto_name_,false);
+			return 0;
+		} else {
+		  event->Add(veto_name_,true);
+			return 0;
+		}
+ } else {
+    if (vec.size() >= min_ && vec.size() <= max_) {
+      return 0;
+    } else {
+      return 1;
+	  }
+  }
+}
+
+// template <>
+// int HTTFilter<CompositeCandidate>::Execute(TreeEvent *event) {
+//   std::vector<CompositeCandidate> & vec = event->Get<std::vector<CompositeCandidate> >(input_label_);
+//   std::vector<CompositeCandidate *> tmp;
+//   tmp.resize(vec.size());
+//   for (unsigned i = 0; i < vec.size(); ++i) {
+//     tmp[i] = &(vec[i]);
+//   }
+//   ic::erase_if(tmp,!boost::bind(predicate_,_1));
+//   std::vector<CompositeCandidate> copy;
+//   copy.resize(tmp.size());
+//   for (unsigned i = 0; i < tmp.size(); ++i) {
+//     copy[i] = *(tmp[i]);
+//   }
+//   event->ForceAdd(input_label_, copy); 
+//   if (tmp.size() >= min_ && tmp.size() <= max_) {
+//     return 0;
+//   } else {
+//     return 1;
+//   }
+// }
+
+template <class T>
+int HTTFilter<T>::PostAnalysis() {
+  return 0;
+}
+
+template <class T>
+void HTTFilter<T>::PrintInfo() {
+  ;
+}
+
+
+
+
+
+}
+
+#endif

--- a/Analysis/HiggsTauTau/interface/HTTPairSelector.h
+++ b/Analysis/HiggsTauTau/interface/HTTPairSelector.h
@@ -11,6 +11,12 @@
 #include <string>
 
 namespace ic {
+  
+  bool SortBySumPt(CompositeCandidate const* c1, CompositeCandidate const* c2);
+  bool SortByIsoET(CompositeCandidate const* c1, CompositeCandidate const* c2);
+  bool SortByIsoMT(CompositeCandidate const* c1, CompositeCandidate const* c2);
+  bool SortByIsoEM(CompositeCandidate const* c1, CompositeCandidate const* c2);
+  bool SortByIsoTT(CompositeCandidate const* c1, CompositeCandidate const* c2);
 
 class HTTPairSelector : public ModuleBase {
  private:
@@ -19,6 +25,7 @@ class HTTPairSelector : public ModuleBase {
   CLASS_MEMBER(HTTPairSelector, std::string, met_label)
   CLASS_MEMBER(HTTPairSelector, bool, mva_met_from_vector)
   CLASS_MEMBER(HTTPairSelector, bool, use_most_isolated)
+  CLASS_MEMBER(HTTPairSelector, bool, use_os_preference)
   CLASS_MEMBER(HTTPairSelector, unsigned, faked_tau_selector)
   CLASS_MEMBER(HTTPairSelector, unsigned, hadronic_tau_selector)
   CLASS_MEMBER(HTTPairSelector, bool, scale_met_for_tau)
@@ -37,6 +44,7 @@ class HTTPairSelector : public ModuleBase {
   virtual int Execute(TreeEvent *event);
   virtual int PostAnalysis();
   virtual void PrintInfo();
+  
 
 };
 

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -151,18 +151,13 @@ namespace ic {
       }
     }
     if(make_sync_ntuple_) {
-		  if(fs_){ 
-        synctree_ = fs_->make<TTree>("TauCheck","TauCheck");
-			} else{
-
-      //Fue to the possibility of other groups requesting different branch names/branch contents
+      //Due to the possibility of other groups requesting different branch names/branch contents
       //we have to make an alternative (albeit very similar) TTree for the sync ntuple. 
       lOFile = new TFile(sync_output_name_.c_str(), "RECREATE");
       lOFile->cd();
       // Tree should be named "TauCheck" to aid scripts which
       // make comparisons between sync trees
       synctree_ = new TTree("TauCheck", "TauCheck");
-			}
 
       // The sync tree is filled for all events passing the di-lepton
       // selections in each channel. This includes vertex selection,
@@ -1012,7 +1007,7 @@ namespace ic {
   }
 
   int HTTCategories::PostAnalysis() {
-    if(make_sync_ntuple_&&!fs_) {   
+    if(make_sync_ntuple_) {   
       lOFile->cd();
       synctree_->Write();
       lOFile->Close();

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -25,6 +25,9 @@ namespace ic {
       fs_ = NULL;
       write_tree_ = true;
       bjet_regression_ = false;
+      make_sync_ntuple_ = false;
+      sync_output_name_ = "SYNC.root";
+      is_embedded_=false;
       kinfit_mode_ = 0; //0 = don't run, 1 = run simple 125,125 default fit, 2 = run extra masses default fit, 3 = run m_bb only fit
   }
 
@@ -36,7 +39,6 @@ namespace ic {
     std::cout << "-------------------------------------" << std::endl;
     std::cout << "HTTCategories" << std::endl;
     std::cout << "-------------------------------------" << std::endl;    
-    if (fs_) {
       std::cout << boost::format(param_fmt()) % "channel"         % Channel2String(channel_);
       std::cout << boost::format(param_fmt()) % "strategy"        % Strategy2String(strategy_);
       std::cout << boost::format(param_fmt()) % "era"             % Era2String(era_);
@@ -46,121 +48,398 @@ namespace ic {
       std::cout << boost::format(param_fmt()) % "mass_shift"      % mass_shift_;
       std::cout << boost::format(param_fmt()) % "write_tree"      % write_tree_;
       std::cout << boost::format(param_fmt()) % "kinfit_mode"     % kinfit_mode_;
+      std::cout << boost::format(param_fmt()) % "make_sync_ntuple" % make_sync_ntuple_;
       std::cout << boost::format(param_fmt()) % "bjet_regression" % bjet_regression_;
 
-      if (write_tree_) {
-        outtree_ = fs_->make<TTree>("ntuple","ntuple");
-        outtree_->Branch("wt",                &wt_);
-        outtree_->Branch("wt_ggh_pt_up",      &wt_ggh_pt_up_);
-        outtree_->Branch("wt_ggh_pt_down",    &wt_ggh_pt_down_);
-        outtree_->Branch("wt_tau_fake_up",    &wt_tau_fake_up_);
-        outtree_->Branch("wt_tau_fake_down",  &wt_tau_fake_down_);
-        outtree_->Branch("wt_tquark_up",      &wt_tquark_up_);
-        outtree_->Branch("wt_tquark_down",    &wt_tquark_down_);
-        outtree_->Branch("wt_tau_id_up",      &wt_tau_id_up_);
-        outtree_->Branch("wt_tau_id_down",    &wt_tau_id_down_);
-        outtree_->Branch("os",                &os_);
-        outtree_->Branch("n_vtx",             &n_vtx_);
-        outtree_->Branch("m_sv",              &m_sv_);
-        outtree_->Branch("m_vis",             &m_vis_);
-        outtree_->Branch("pt_h",              &pt_h_);
-        outtree_->Branch("pt_tt",             &pt_tt_);
-        outtree_->Branch("mt_1",              &mt_1_);
-        outtree_->Branch("pzeta",             &pzeta_);
-        outtree_->Branch("pt_1",              &pt_1_);
-        outtree_->Branch("pt_2",              &pt_2_);
-        outtree_->Branch("eta_1",             &eta_1_);
-        outtree_->Branch("eta_2",             &eta_2_);
-        outtree_->Branch("iso_2",             &iso_2_);
-        outtree_->Branch("z_2",               &z_2_);
-        outtree_->Branch("m_2",               &m_2_);
-        outtree_->Branch("met",               &met_);
-        outtree_->Branch("met_phi",           &met_phi_);
-        outtree_->Branch("tau_decay_mode",    &tau_decay_mode_);
-        outtree_->Branch("n_jets",            &n_jets_);
-        outtree_->Branch("n_lowpt_jets",      &n_lowpt_jets_);
-        outtree_->Branch("n_bjets",           &n_bjets_);
-        outtree_->Branch("n_prebjets",        &n_prebjets_);
-        outtree_->Branch("n_jets_csv",        &n_jets_csv_);
-        outtree_->Branch("n_bjets_csv",       &n_bjets_csv_);
-        outtree_->Branch("n_loose_bjets",     &n_loose_bjets_);
-        outtree_->Branch("n_jetsingap",       &n_jetsingap_);
-        outtree_->Branch("jpt_1",             &jpt_1_);
-        outtree_->Branch("j1_dm",             &j1_dm_);
-        outtree_->Branch("jpt_2",             &jpt_2_);
-        outtree_->Branch("jeta_1",            &jeta_1_);
-        outtree_->Branch("jeta_2",            &jeta_2_);
-        outtree_->Branch("bpt_1",             &bpt_1_);
-        outtree_->Branch("beta_1",            &beta_1_);
-        outtree_->Branch("bcsv_1",            &bcsv_1_);
-        outtree_->Branch("jet_csvpt_1",       &jet_csvpt_1_);
-        outtree_->Branch("jet_csvEt_1",       &jet_csvEt_1_);
-        outtree_->Branch("jet_csveta_1",      &jet_csveta_1_);
-        outtree_->Branch("jet_csvbcsv_1",     &jet_csvbcsv_1_);
-        outtree_->Branch("jet_csvpt_2",       &jet_csvpt_2_);
-        outtree_->Branch("jet_csvpt_bb",	  &jet_csvpt_bb_);
-        outtree_->Branch("jet_csv_dR",		  &jet_csv_dR_);
-        outtree_->Branch("jet_csveta_2",      &jet_csveta_2_);
-        outtree_->Branch("jet_csvbcsv_2",     &jet_csvbcsv_2_);
-        outtree_->Branch("mjj",               &mjj_);
-        outtree_->Branch("mjj_h",             &mjj_h_);
-        outtree_->Branch("mbb_h",             &mbb_h_);
-        outtree_->Branch("mjj_tt",            &mjj_tt_);
-        outtree_->Branch("m_H_best",               &m_H_best_);
-        outtree_->Branch("m_H_chi2_best",               &m_H_chi2_best_);
-        outtree_->Branch("pull_balance_H_best", &pull_balance_H_best_);
-        outtree_->Branch("convergence_H_best", &convergence_H_best_); 
-        outtree_->Branch("m_H_hZ",          &m_H_hZ_);
-        outtree_->Branch("m_H_hZ_chi2",     &m_H_hZ_chi2_);
-        outtree_->Branch("pull_balance_hZ", &pull_balance_hZ_);
-        outtree_->Branch("convergence_hZ", &convergence_hZ_);
-        outtree_->Branch("m_H_Zh",          &m_H_Zh_);
-        outtree_->Branch("m_H_Zh_chi2",     &m_H_Zh_chi2_);
-        outtree_->Branch("pull_balance_Zh",  &pull_balance_Zh_);
-        outtree_->Branch("convergence_Zh",  &convergence_Zh_);
-        outtree_->Branch("m_H_hh",     &m_H_hh_);
-        outtree_->Branch("m_H_hh_all",     &m_H_hh_all_);
-        outtree_->Branch("m_H_hh_chi2",     &m_H_hh_chi2_);
-        outtree_->Branch("pull_balance_hh", &pull_balance_hh_);
-        outtree_->Branch("convergence_hh", &convergence_hh_);
-        outtree_->Branch("m_bb",     &m_bb_);
-        outtree_->Branch("m_bb_chi2",     &m_bb_chi2_);
-        outtree_->Branch("pull_balance_bb", &pull_balance_bb_);
-        outtree_->Branch("convergence_bb", &convergence_bb_);
-        outtree_->Branch("jdeta",             &jdeta_);
-        outtree_->Branch("jet_csv_mjj",               &jet_csv_mjj_);
-        outtree_->Branch("jet_csv_dphi",               &jet_csv_dphi_);
-        outtree_->Branch("jet_csv_deta",             &jet_csv_deta_);
-        outtree_->Branch("jet_csv_dtheta",             &jet_csv_dtheta_);
-        outtree_->Branch("mjj_lowpt",         &mjj_lowpt_);
-        outtree_->Branch("jdeta_lowpt",       &jdeta_lowpt_);
-        outtree_->Branch("n_jetsingap_lowpt", &n_jetsingap_lowpt_);
-        outtree_->Branch("l1_met",            &l1_met_);
-        outtree_->Branch("calo_nohf_met",     &calo_nohf_met_);
-        if (channel_ == channel::em) {
-          outtree_->Branch("em_gf_mva",         &em_gf_mva_);
-          // outtree_->Branch("em_vbf_mva",        &em_vbf_mva_);
-          outtree_->Branch("pzetavis",          &pzetavis_);
-          outtree_->Branch("pzetamiss",         &pzetamiss_);
-          outtree_->Branch("mt_ll",             &mt_ll_);
-          outtree_->Branch("emu_dphi",          &emu_dphi_);
-          outtree_->Branch("emu_csv",           &emu_csv_);
-          outtree_->Branch("emu_dxy_1",         &emu_dxy_1_);
-          outtree_->Branch("emu_dxy_2",         &emu_dxy_2_);
-        }
+    if (fs_ && write_tree_) {
+      outtree_ = fs_->make<TTree>("ntuple","ntuple");
+      outtree_->Branch("wt",                &wt_);
+      outtree_->Branch("wt_ggh_pt_up",      &wt_ggh_pt_up_);
+      outtree_->Branch("wt_ggh_pt_down",    &wt_ggh_pt_down_);
+      outtree_->Branch("wt_tau_fake_up",    &wt_tau_fake_up_);
+      outtree_->Branch("wt_tau_fake_down",  &wt_tau_fake_down_);
+      outtree_->Branch("wt_tquark_up",      &wt_tquark_up_);
+      outtree_->Branch("wt_tquark_down",    &wt_tquark_down_);
+      outtree_->Branch("wt_tau_id_up",      &wt_tau_id_up_);
+      outtree_->Branch("wt_tau_id_down",    &wt_tau_id_down_);
+      outtree_->Branch("os",                &os_);
+      outtree_->Branch("n_vtx",             &n_vtx_);
+      outtree_->Branch("m_sv",              &m_sv_);
+      outtree_->Branch("m_vis",             &m_vis_);
+      outtree_->Branch("pt_h",              &pt_h_);
+      outtree_->Branch("pt_tt",             &pt_tt_);
+      outtree_->Branch("mt_1",              &mt_1_);
+      outtree_->Branch("pzeta",             &pzeta_);
+      outtree_->Branch("pt_1",              &pt_1_);
+      outtree_->Branch("pt_2",              &pt_2_);
+      outtree_->Branch("eta_1",             &eta_1_);
+      outtree_->Branch("eta_2",             &eta_2_);
+      outtree_->Branch("iso_2",             &iso_2_);
+      outtree_->Branch("z_2",               &z_2_);
+      outtree_->Branch("m_2",               &m_2_);
+      outtree_->Branch("met",               &met_);
+      outtree_->Branch("met_phi",           &met_phi_);
+      outtree_->Branch("tau_decay_mode",    &tau_decay_mode_);
+      outtree_->Branch("n_jets",            &n_jets_);
+      outtree_->Branch("n_lowpt_jets",      &n_lowpt_jets_);
+      outtree_->Branch("n_bjets",           &n_bjets_);
+      outtree_->Branch("n_prebjets",        &n_prebjets_);
+      outtree_->Branch("n_jets_csv",        &n_jets_csv_);
+      outtree_->Branch("n_bjets_csv",       &n_bjets_csv_);
+      outtree_->Branch("n_loose_bjets",     &n_loose_bjets_);
+      outtree_->Branch("n_jetsingap",       &n_jetsingap_);
+      outtree_->Branch("jpt_1",             &jpt_1_);
+      outtree_->Branch("j1_dm",             &j1_dm_);
+      outtree_->Branch("jpt_2",             &jpt_2_);
+      outtree_->Branch("jeta_1",            &jeta_1_);
+      outtree_->Branch("jeta_2",            &jeta_2_);
+      outtree_->Branch("bpt_1",             &bpt_1_);
+      outtree_->Branch("beta_1",            &beta_1_);
+      outtree_->Branch("bcsv_1",            &bcsv_1_);
+      outtree_->Branch("jet_csvpt_1",       &jet_csvpt_1_);
+      outtree_->Branch("jet_csvEt_1",       &jet_csvEt_1_);
+      outtree_->Branch("jet_csveta_1",      &jet_csveta_1_);
+      outtree_->Branch("jet_csvbcsv_1",     &jet_csvbcsv_1_);
+      outtree_->Branch("jet_csvpt_2",       &jet_csvpt_2_);
+      outtree_->Branch("jet_csvpt_bb",	  &jet_csvpt_bb_);
+      outtree_->Branch("jet_csv_dR",		  &jet_csv_dR_);
+      outtree_->Branch("jet_csveta_2",      &jet_csveta_2_);
+      outtree_->Branch("jet_csvbcsv_2",     &jet_csvbcsv_2_);
+      outtree_->Branch("mjj",               &mjj_);
+      outtree_->Branch("mjj_h",             &mjj_h_);
+      outtree_->Branch("mbb_h",             &mbb_h_);
+      outtree_->Branch("mjj_tt",            &mjj_tt_);
+      outtree_->Branch("m_H_best",               &m_H_best_);
+      outtree_->Branch("m_H_chi2_best",               &m_H_chi2_best_);
+      outtree_->Branch("pull_balance_H_best", &pull_balance_H_best_);
+      outtree_->Branch("convergence_H_best", &convergence_H_best_); 
+      outtree_->Branch("m_H_hZ",          &m_H_hZ_);
+      outtree_->Branch("m_H_hZ_chi2",     &m_H_hZ_chi2_);
+      outtree_->Branch("pull_balance_hZ", &pull_balance_hZ_);
+      outtree_->Branch("convergence_hZ", &convergence_hZ_);
+      outtree_->Branch("m_H_Zh",          &m_H_Zh_);
+      outtree_->Branch("m_H_Zh_chi2",     &m_H_Zh_chi2_);
+      outtree_->Branch("pull_balance_Zh",  &pull_balance_Zh_);
+      outtree_->Branch("convergence_Zh",  &convergence_Zh_);
+      outtree_->Branch("m_H_hh",     &m_H_hh_);
+      outtree_->Branch("m_H_hh_all",     &m_H_hh_all_);
+      outtree_->Branch("m_H_hh_chi2",     &m_H_hh_chi2_);
+      outtree_->Branch("pull_balance_hh", &pull_balance_hh_);
+      outtree_->Branch("convergence_hh", &convergence_hh_);
+      outtree_->Branch("m_bb",     &m_bb_);
+      outtree_->Branch("m_bb_chi2",     &m_bb_chi2_);
+      outtree_->Branch("pull_balance_bb", &pull_balance_bb_);
+      outtree_->Branch("convergence_bb", &convergence_bb_);
+      outtree_->Branch("jdeta",             &jdeta_);
+      outtree_->Branch("jet_csv_mjj",               &jet_csv_mjj_);
+      outtree_->Branch("jet_csv_dphi",               &jet_csv_dphi_);
+      outtree_->Branch("jet_csv_deta",             &jet_csv_deta_);
+      outtree_->Branch("jet_csv_dtheta",             &jet_csv_dtheta_);
+      outtree_->Branch("mjj_lowpt",         &mjj_lowpt_);
+      outtree_->Branch("jdeta_lowpt",       &jdeta_lowpt_);
+      outtree_->Branch("n_jetsingap_lowpt", &n_jetsingap_lowpt_);
+      outtree_->Branch("l1_met",            &l1_met_);
+      outtree_->Branch("calo_nohf_met",     &calo_nohf_met_);
+      if (channel_ == channel::em) {
+        outtree_->Branch("em_gf_mva",         &em_gf_mva_);
+        // outtree_->Branch("em_vbf_mva",        &em_vbf_mva_);
+        outtree_->Branch("pzetavis",          &pzetavis_);
+        outtree_->Branch("pzetamiss",         &pzetamiss_);
+        outtree_->Branch("mt_ll",             &mt_ll_);
+        outtree_->Branch("emu_dphi",          &emu_dphi_);
+        outtree_->Branch("emu_csv",           &emu_csv_);
+        outtree_->Branch("emu_dxy_1",         &emu_dxy_1_);
+        outtree_->Branch("emu_dxy_2",         &emu_dxy_2_);
       }
     }
+    if(make_sync_ntuple_) {
+      //Due to the possibility of other groups requesting different branch names/branch contents
+      //we have to make an alternative (albeit very similar) TTree for the sync ntuple. 
+      lOFile = new TFile(sync_output_name_.c_str(), "RECREATE");
+      lOFile->cd();
+      // Tree should be named "TauCheck" to aid scripts which
+      // make comparisons between sync trees
+      synctree_ = new TTree("TauCheck", "TauCheck");
 
+      // The sync tree is filled for all events passing the di-lepton
+      // selections in each channel. This includes vertex selection,
+      // trigger, ID, isolation, di-lepton and extra lepton vetoes.
+      // Topological (e.g. mT) and opposite-charge requirements are
+      // not applied.
+
+      // Note: not all of the following variables were in the original
+      // list of sync tree variables, and not all are necessary/used in
+      // the legacy htt anaylsis
+
+      // Lepton properties are numbered as follows for each channel:
+      // electron     (1)  + tau        (2)
+      // muon         (1)  + tau        (2)
+      // electron     (1)  + muon       (2)
+      // high pT tau  (1)  + low pT tau (2)
+
+      // Run
+      synctree_->Branch("run", &run_, "run/I");
+      // Lumi
+      synctree_->Branch("lumi", &lumi_, "lumi/I");
+      // Event
+      synctree_->Branch("evt", &event_, "event/I");
+
+      // Number of primary vertices passing good vertex selection
+      synctree_->Branch("npv", &n_vtx_, "n_vtx/I");
+      // Number of in-time pileup interactions (used for pileup reweighting)
+      synctree_->Branch("npu", &n_pu_, "n_pu/I");
+      // The rho used for jet energy corrections
+      synctree_->Branch("rho", &rho_, "rho/F");
+
+      // The lumi scaling factor for mc * additional weights
+      // (not filled in IC trees!)
+      synctree_->Branch("mcweight", &mc_weight_, "mc_weight/F");
+      // Pileup weight
+      synctree_->Branch("puweight", &pu_weight_, "pu_weight/F");
+
+      // Tag-and-probe weights for leptons
+      // Total trigger weight for lepton 1
+      synctree_->Branch("trigweight_1", &trigweight_1_, "trigweight_1/F");
+      // Total trigger weight for lepton 2
+      synctree_->Branch("trigweight_2", &trigweight_2_, "trigweight_2/F");
+      // Total ID weight for lepton 1
+      synctree_->Branch("idweight_1", &idweight_1_, "idweight_1/F");
+      // Total ID weight for lepton 2
+      synctree_->Branch("idweight_2", &idweight_2_, "idweight_2/F");
+      // Total iso weight for lepton 1
+      synctree_->Branch("isoweight_1", &isoweight_1_, "isoweight_1/F");
+      // Total iso weight for lepton 2
+      synctree_->Branch("isoweight_2", &isoweight_2_, "isoweight_2/F");
+     // Product of all trigger, ID and iso weights
+      synctree_->Branch("effweight", &effweight_, "effweight/F");
+      // Jet->tau fake rate weight (pT-dependent)
+      synctree_->Branch("fakeweight", &fakeweight_, "fakeweight/F");
+      // Product of all embedded weights, but only for rechit samples
+      synctree_->Branch("embeddedWeight", &embeddedweight_, "embeddedweight/F");
+      // Higgs pt weights (for ggh samples)
+      synctree_->Branch("signalWeight", &signalweight_, "signalweight/F");
+      // Total combined event weight (excluding lumi weighting)
+      // NB: may contain weights not included in the above
+      synctree_->Branch("weight", &wt_, "wt/F");
+
+      // Visible di-tau mass
+      synctree_->Branch("m_vis", &m_vis_, "m_vis/F");
+      // SVFit di-tau mass
+      synctree_->Branch("m_sv", &m_sv_, "m_sv/F");
+      // SVFit di-tau pt (only for Markov-Chain SVFit)
+      synctree_->Branch("pt_sv", &pt_h_, "pt_h/F");
+      // SVFit di-tau eta (only for Markov-Chain SVFit)
+      synctree_->Branch("eta_sv", &eta_h_, "eta_h/F");
+      // SVFit di-tau phi (only for Markov-Chain SVFit)
+      synctree_->Branch("phi_sv", &phi_h_, "phi_h/F");
+
+      // Lepton 1 properties
+      // pt (including effect of any energy scale corrections)
+      synctree_->Branch("pt_1", &pt_1_, "pt_1/F");
+      // phi
+      synctree_->Branch("phi_1", &phi_1_, "phi_1/F");
+      // eta
+      synctree_->Branch("eta_1", &eta_1_, "eta_1/F");
+      // mass
+      synctree_->Branch("m_1", &m_1_, "m_1/F");
+      // charge
+      synctree_->Branch("q_1", &q_1_, "q_1/I");
+      // delta-beta corrected isolation (relative or absolute as appropriate)
+      // If lepton 1 is a tau, this is the value of byIsolationMVAraw,
+      // which is no longer used in the analysis, but retained for legacy
+      // reasons
+      synctree_->Branch("iso_1", &iso_1_, "iso_1/F");
+      // If an electron, the output of the ID MVA, zero otherwise
+      synctree_->Branch("mva_1", &mva_1_, "mva_1/F");
+      // Transverse (x-y) impact parameter w.r.t to the primary vertex
+      synctree_->Branch("d0_1", &d0_1_, "d0_1/F");
+      // Longitudinal (z) impact parameter w.r.t to the primary vertex
+      synctree_->Branch("dZ_1", &dz_1_, "dz_1/F");
+      // Whether lepton passes ID selection (always true in IC ntuples)
+//      synctree_->Branch("passid_1", &lPassId1, "lPassId1/B");
+      // Whether lepton passes iso selection (always true in IC ntuples)
+//      synctree_->Branch("passiso_1", &lPassIso1, "lPassIso1/B");
+      // Transverse mass of lepton 1 and MVA MET
+      synctree_->Branch("mt_1", &mt_1_, "mt_1/F");
+
+      // Lepton 2 properties
+      // pt (including effect of any energy scale corrections)
+      synctree_->Branch("pt_2", &pt_2_, "pt_2/F");
+      // phi
+      synctree_->Branch("phi_2", &phi_2_, "lPhi2/F");
+      // eta
+      synctree_->Branch("eta_2", &eta_2_, "lEta2/F");
+      // mass
+      synctree_->Branch("m_2", &m_2_, "lM2/F");
+      // charge
+      synctree_->Branch("q_2", &q_2_, "lq2/I");
+      // delta-beta corrected isolation (relative or absolute as appropriate)
+      // If lepton 2 is a tau, this is the value of byIsolationMVAraw,
+      // which is no longer used in the analysis, but retained for legacy
+      // reasons
+      synctree_->Branch("iso_2", &iso_2_, "iso_2/F");
+      // Transverse (x-y) impact parameter w.r.t to the primary vertex
+      synctree_->Branch("d0_2", &d0_2_, "d0_2/F");
+      // Longitudinal (z) impact parameter w.r.t to the primary vertex
+      synctree_->Branch("dZ_2", &dz_2_, "dz_2/F");
+      // If an electron, the output of the ID MVA, zero otherwise
+      synctree_->Branch("mva_2", &mva_2_, "mva_2/F");
+      // Whether lepton passes ID selection (always true in IC ntuples)
+//      synctree_->Branch("passid_2", &lPassId2, "lPassId2/B");
+      // Whether lepton passes iso selection (always true in IC ntuples)
+//      synctree_->Branch("passiso_2", &lPassIso2, "lPassIso2/B");
+      // Transverse mass of lepton 2 and MVA MET
+      synctree_->Branch("mt_2", &mt_2_, "mt_2/F");
+
+      // Variables defined when lepton 2 is a tau
+      // raw value of the 3hits delta-beta isolation
+
+      /*synctree_->Branch("byCombinedIsolationDeltaBetaCorrRaw3Hits_2", &l3Hits_2,
+                     "byCombinedIsolationDeltaBetaCorrRaw3Hits_2/F");
+      // raw value of the anti-electron MVA3 output
+      synctree_->Branch("againstElectronMVA3raw_2", &lagainstElectronMVA3raw_2,
+                     "againstElectronMVA3raw_2/F");
+      // raw value of the MVA2 isolation
+      synctree_->Branch("byIsolationMVA2raw_2", &lbyIsolationMVA2raw_2,
+                     "byIsolationMVA2raw_2/F");
+      // output of againstMuonLoose2
+      synctree_->Branch("againstMuonLoose2_2", &lagainstMuonLoose2_2,
+                     "againstMuonLoose2_2/F");
+      // output of againstMuonMedium2
+      synctree_->Branch("againstMuonMedium2_2", &lagainstMuonMedium2_2,
+                     "againstMuonMedium2_2/F");
+      // output of againstMuonTight2
+      synctree_->Branch("againstMuonTight2_2", &lagainstMuonTight2_2,
+                     "againstMuonTight2_2/F");
+*/
+      // Uncorrected PF MET (not used in analysis)
+      synctree_->Branch("met", &pfmet_, "pfmet_/F");
+      // Uncorrected PF MET phi (not used in analysis)
+      synctree_->Branch("metphi", &pfmet_phi_, "pfmet_phi_/F");
+      // Elements of the PF MET covariance matrix (not used in analysis)
+      synctree_->Branch("metcov00", &pfmetCov00_, "pfmetCov00/F");
+      synctree_->Branch("metcov01", &pfmetCov01_, "pfmetCov01/F");
+      synctree_->Branch("metcov10", &pfmetCov10_, "pfmetCov10/F");
+      synctree_->Branch("metcov11", &pfmetCov11_, "pfmetCov11/F");
+
+      // MVA MET
+      synctree_->Branch("mvamet", &met_, "met/F");
+      // MVA MET phi
+      synctree_->Branch("mvametphi", &met_phi_, "met_phi/F");
+      // Elements of the MVA MET covariance matrix
+      synctree_->Branch("mvacov00", &metCov00_, "metCov00/F");
+      synctree_->Branch("mvacov01", &metCov01_, "metCov01/F");
+      synctree_->Branch("mvacov10", &metCov10_, "metCov10/F");
+      synctree_->Branch("mvacov11", &metCov11_, "metCov11/F");
+
+      // pt of the di-tau + MET system
+      synctree_->Branch("pt_tt", &pt_tt_, "pt_tt/F");
+
+      // Visible pzeta
+      synctree_->Branch("pzetavis", &pzetavis_, "pzetavis/F");
+      // MET pzeta
+      synctree_->Branch("pzetamiss", &pzetamiss_, "pzetamiss/F");
+      // ttbar-rejection MVA output (emu channel only)
+      synctree_->Branch("mva_gf", &em_gf_mva_, "em_gf_mva/F");
+
+      // Jet properties
+      // The following properties are for the leading (1) and sub-leading (2) jets
+      // with pt > 30, |eta| < 4.7 after jet energy corrections, PF jet ID and
+      // pileup jet ID are applied. Jets overlapping with either selected lepton
+      // are not counted
+
+      // Number of jets passing above selection
+      synctree_->Branch("njets", &n_jets_, "n_jets_/I");
+      // Number of jets passing above selection but with
+      // pt > 20 instead of pt > 30
+//      synctree_->Branch("njetspt20", &lNJetsPt20, "lNJetsPt20/I");
+
+      // Leading Jet
+      // pt
+      synctree_->Branch("jpt_1", &jpt_1_, "jpt_1/F");
+      // eta
+      synctree_->Branch("jeta_1", &jeta_1_, "jeta_1/F");
+      // phi
+      synctree_->Branch("jphi_1", &jphi_1_, "jphi_1/F");
+      // raw pt (before JEC)
+//      synctree_->Branch("jptraw_1", &lJPtRaw1, "lJPtRaw1/F");
+      // pt uncertainty relative to corrected pt (not in IC ntuples)
+//      synctree_->Branch("jptunc_1", &lJPtUnc1, "lJPtUnc1/F");
+      // Pileup ID MVA output
+//      synctree_->Branch("jmva_1", &lJMVA1, "lJMVA1/F");
+      // Linear radial moment (not used in htt analysis)
+//      synctree_->Branch("jlrm_1", &lLRM1, "lLRM1/F");
+      // Charged track multiplicity (not used in htt analysis)
+//      synctree_->Branch("jctm_1", &lCTM1, "lCTM1/I");
+
+      // Sub-leading Jet
+      // pt
+      synctree_->Branch("jpt_2", &jpt_2_, "jpt_2/F");
+      // eta
+      synctree_->Branch("jeta_2", &jeta_2_, "jeta_2/F");
+      // phi
+      synctree_->Branch("jphi_2", &jphi_2_, "jphi_2/F");
+      // raw pt (before JEC)
+//      synctree_->Branch("jptraw_2", &lJPtRaw2, "lJPtRaw2/F");
+      // pt uncertainty relative to corrected pt (not in IC ntuples)
+//      synctree_->Branch("jptunc_2", &lJPtUnc2, "lJPtUnc2/F");
+      // Pileup ID MVA output
+//      synctree_->Branch("jmva_2", &lJMVA2, "lJMVA2/F");
+      // Linear radial moment (not used in htt analysis)
+//      synctree_->Branch("jlrm_2", &lLRM2, "lLRM2/F");
+      // Charged track multiplicity (not used in htt analysis)
+//      synctree_->Branch("jctm_2", &lCTM2, "lCTM2/I");
+
+      // Di-jet properties
+      // Calculated with leading and sub-leading jets when njets >= 2
+      // di-jet mass
+      synctree_->Branch("mjj", &mjj_, "mjj/F");
+      // absolute difference in eta
+      synctree_->Branch("jdeta", &jdeta_, "jdeta/F");
+      // number of jets, passing above selections, in pseudorapidity gap
+      // between jets
+//      synctree_->Branch("njetingap", &lNJetInGap, "lNJetInGap/I");
+
+      // B-Tagged Jet properties
+      // The following properties are for the leading (in pt) CSV medium b-tagged
+      // jet with pt > 20, |eta| < 2.4 after jet energy corrections, PF jet ID and
+      // pileup jet ID are applied. Jets overlapping with either selected lepton
+      // are not counted
+
+      // Number of b-tagging jets passing above selections
+      synctree_->Branch("nbtag", &n_bjets_, "n_bjets/I");
+      // pt
+      synctree_->Branch("bpt", &bpt_1_, "bpt_1/F");
+      // eta
+      synctree_->Branch("beta", &beta_1_, "beta_1/F");
+      // phi
+      synctree_->Branch("bphi", &bphi_1_, "bphi_1/F");
+    }
     return 0;
   }
 
   int HTTCategories::Execute(TreeEvent *event) {
 
-
     // Get the objects we need from the event
     EventInfo const* eventInfo = event->GetPtr<EventInfo>("eventInfo");
 
     wt_ = eventInfo->total_weight();
+    run_ = eventInfo->run();
+    event_ = eventInfo->event();
+    lumi_ = eventInfo->lumi_block();
+    std::vector<PileupInfo *> puInfo;
+    float true_int = -1;
+
+    if (event->Exists("pileupInfo")) {
+     puInfo = event->GetPtrVec<PileupInfo>("pileupInfo");
+      for (unsigned i = 0; i < puInfo.size(); ++i) {
+        if (puInfo[i]->bunch_crossing() == 0)
+          true_int = puInfo[i]->true_num_interactions();
+      }
+    }
+    n_pu_ = true_int;
+    rho_ = eventInfo->jet_rho();
+    
     wt_ggh_pt_up_ = 1.0;
     wt_ggh_pt_down_ = 1.0;
     wt_tau_fake_up_ = 1.0;
@@ -177,7 +456,36 @@ namespace ic {
     if (event->Exists("wt_tquark_down"))    wt_tquark_down_ = event->Get<double>("wt_tquark_down");
     if (event->Exists("wt_tau_id_up"))      wt_tau_id_up_   = event->Get<double>("wt_tau_id_up");
     if (event->Exists("wt_tau_id_down"))    wt_tau_id_down_ = event->Get<double>("wt_tau_id_down");
-    
+  
+  mc_weight_ = 0.0;
+  if (!is_embedded_ && event->Exists("pileupInfo")) pu_weight_ = eventInfo->weight("pileup");
+  if (event->Exists("trigweight_1")) trigweight_1_ = event->Get<double>("trigweight_1");
+  if (event->Exists("trigweight_2")) trigweight_2_ = event->Get<double>("trigweight_2");
+  if (event->Exists("idweight_1")) idweight_1_ = event->Get<double>("idweight_1");
+  if (event->Exists("idweight_2")) idweight_2_ = event->Get<double>("idweight_2");
+  if (event->Exists("isoweight_1")) isoweight_1_ = event->Get<double>("isoweight_1");
+  if (event->Exists("isoweight_2")) isoweight_2_ = event->Get<double>("isoweight_2");
+  if (eventInfo->weight_defined("lepton")) effweight_ = eventInfo->weight("lepton");
+  if (eventInfo->weight_defined("tau_fake_weight")) fakeweight_ = eventInfo->weight("tau_fake_weight");
+  if (eventInfo->weight_defined("tau_mode_scale")) effweight_ *= eventInfo->weight("tau_mode_scale");
+   
+  if (eventInfo->weight_defined("tauspinner")) {
+    embeddedweight_ = eventInfo->weight("tauspinner") *
+      eventInfo->weight("zmm_eff") *
+      //eventInfo->weight("muon_rad") *
+      eventInfo->weight("kin_weight1") *
+      eventInfo->weight("kin_weight2") *
+      eventInfo->weight("kin_weight3") *
+      eventInfo->weight("embed_weight");
+   } else {
+    embeddedweight_ = 0.;
+   }
+  if (eventInfo->weight_defined("ggh")) {
+    signalweight_ = eventInfo->weight("ggh");
+   } else {
+    signalweight_ = 0.;
+   }
+
     std::vector<CompositeCandidate *> const& ditau_vec = event->GetPtrVec<CompositeCandidate>(ditau_label_);
     CompositeCandidate const* ditau = ditau_vec.at(0);
     Candidate const* lep1 = ditau->GetCandidate("lepton1");
@@ -235,9 +543,14 @@ namespace ic {
     }
 
     if (event->Exists("svfitHiggs")) {
-      pt_h_ = event->Get<Candidate>("svfitHiggs").pt();
+      Candidate const& higgs = event->Get<Candidate>("svfitHiggs");
+      pt_h_ = higgs.pt();
+      eta_h_ = higgs.eta();
+      phi_h_ = higgs.phi();
     } else {
       pt_h_ = -9999;
+      eta_h_ = -9999;
+      phi_h_ = -9999;
     }
 
     pt_tt_ = (ditau->vector() + met->vector()).pt();
@@ -258,9 +571,8 @@ namespace ic {
       m_vis_ = m_vis_ * event->Get<double>("mass_scale");
     }
 
-
-
     mt_1_ = MT(lep1, met);
+    mt_2_ = MT(lep2, met);
     mt_ll_ = MT(ditau, met);
     pzeta_ = PZeta(ditau, met, 0.85);
     pzetavis_ = PZetaVis(ditau);
@@ -271,37 +583,103 @@ namespace ic {
     pt_2_ = lep2->pt();
     eta_1_ = lep1->eta();
     eta_2_ = lep2->eta();
-
+    phi_1_ = lep1->phi();
+    phi_2_ = lep2->phi();
+    m_1_ = lep1->M();
     m_2_ = lep2->M();
+    q_1_ = lep1->charge();
+    q_2_ = lep2->charge();
     met_ = met->pt();
     met_phi_ = met->phi();
 
+    metCov00_ = met->xx_sig();
+    metCov10_ = met->yx_sig();
+    metCov01_ = met->xy_sig();
+    metCov11_ = met->yy_sig();
+    
+    Met const* pfmet = NULL;
+    //slightly different pfMET format for new ntuples
+    if(strategy_ == strategy::paper2013) pfmet = event->GetPtr<Met>("pfMet");
+    if(strategy_ == strategy::phys14) {
+      std::vector<Met*> pfMet_vec = event->GetPtrVec<Met>("pfMet");
+      pfmet = pfMet_vec.at(0);  
+    }
+    pfmet_ = pfmet->pt();
+    pfmet_phi_ = pfmet->phi();
+  
+    pfmetCov00_ = pfmet->xx_sig();
+    pfmetCov01_ = pfmet->xy_sig();
+    pfmetCov10_ = pfmet->yx_sig();
+    pfmetCov11_ = pfmet->yy_sig();
+    
     emu_dxy_1_ = 0.0;
     emu_dxy_2_ = 0.0;
 
     if (channel_ == channel::et) {
       Electron const* elec = dynamic_cast<Electron const*>(lep1);
-      iso_1_ = PF04IsolationVal(elec, 0.5);
-      if(strategy_ == strategy::phys14) iso_1_ = PF03IsolationVal(elec, 0.5, 0);
       Tau const* tau = dynamic_cast<Tau const*>(lep2);
-      iso_2_ = tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits");
+      d0_1_ = elec->dxy_vertex();
+      dz_1_ = elec->dz_vertex();
+      if(strategy_ == strategy::paper2013) {
+        iso_1_ = PF04IsolationVal(elec, 0.5);
+        mva_1_ = elec->GetIdIso("mvaNonTrigV0");
+        iso_2_ = tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits");
+        mva_2_ = tau->GetTauID("againstElectronMVA");
+//        l3Hits_2 = tau->HasTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits") ? tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits") : 0. ;
+//        lagainstElectronMVA3raw_2 = tau->HasTauID("againstElectronMVA3raw") ? tau->GetTauID("againstElectronMVA3raw") : 0. ;
+//        lbyIsolationMVA2raw_2 = tau->HasTauID("byIsolationMVA2raw") ? tau->GetTauID("byIsolationMVA2raw") : 0. ;
+//        lagainstMuonLoose2_2 = tau->HasTauID("againstMuonLoose2") ? tau->GetTauID("againstMuonLoose2") : 0. ;
+//        lagainstMuonMedium2_2 = tau->HasTauID("againstMuonMedium2") ? tau->GetTauID("againstMuonMedium2") : 0. ;
+ //       lagainstMuonTight2_2 = tau->HasTauID("againstMuonTight2") ? tau->GetTauID("againstMuonTight2") : 0. ;
+      }
+      if(strategy_ == strategy::phys14) {
+        iso_1_ = PF03IsolationVal(elec, 0.5, 0);
+        mva_1_ = elec->GetIdIso("mvaNonTrigV025nsPHYS14");
+        iso_2_ = tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits");
+        mva_2_ = tau->GetTauID("againstElectronMVA5raw");
+      }
     }
     if (channel_ == channel::mt || channel_ == channel::mtmet) {
       Muon const* muon = dynamic_cast<Muon const*>(lep1);
-      iso_1_ = PF04IsolationVal(muon, 0.5);
-      if(strategy_ == strategy::phys14) iso_1_ = PF03IsolationVal(muon, 0.5, 0);
       Tau const* tau = dynamic_cast<Tau const*>(lep2);
-      iso_2_ = tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits");
+      d0_1_ = muon->dxy_vertex();
+      dz_1_ = muon->dz_vertex();
+      if(strategy_ == strategy::paper2013) {
+        iso_1_ = PF04IsolationVal(muon, 0.5);
+        mva_1_ = 0.0;
+        iso_2_ = tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits");
+        mva_2_ = tau->GetTauID("againstElectronMVA");
+//        l3Hits_2 = tau->HasTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits") ? tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits") : 0. ;
+//        lagainstElectronMVA3raw_2 = tau->HasTauID("againstElectronMVA3raw") ? tau->GetTauID("againstElectronMVA3raw") : 0. ;
+//        lbyIsolationMVA2raw_2 = tau->HasTauID("byIsolationMVA2raw") ? tau->GetTauID("byIsolationMVA2raw") : 0. ;
+//        lagainstMuonLoose2_2 = tau->HasTauID("againstMuonLoose2") ? tau->GetTauID("againstMuonLoose2") : 0. ;
+//        lagainstMuonMedium2_2 = tau->HasTauID("againstMuonMedium2") ? tau->GetTauID("againstMuonMedium2") : 0. ;
+ //       lagainstMuonTight2_2 = tau->HasTauID("againstMuonTight2") ? tau->GetTauID("againstMuonTight2") : 0. ;
+      }
+      if(strategy_ == strategy::phys14) {
+        iso_1_ = PF03IsolationVal(muon, 0.5, 0);
+        mva_1_ = 0.0;
+        iso_2_ = tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits");
+        mva_2_ = tau->GetTauID("againstElectronMVA5raw");
+      }
     }
     if (channel_ == channel::em) {
       Electron const* elec = dynamic_cast<Electron const*>(lep1);
-      iso_1_ = PF04IsolationVal(elec, 0.5);
-      if(strategy_ == strategy::phys14) iso_1_ = PF03IsolationVal(elec, 0.5, 0);
       Muon const* muon = dynamic_cast<Muon const*>(lep2);
-      iso_2_ = PF04IsolationVal(muon, 0.5);
-      if(strategy_ == strategy::phys14) iso_2_ = PF03IsolationVal(muon, 0.5, 0);
+      if(strategy_ == strategy::paper2013) {
+        iso_1_ = PF04IsolationVal(elec, 0.5);
+        iso_2_ = PF04IsolationVal(muon, 0.5);
+      }
+      if(strategy_ == strategy::phys14) {
+        iso_1_ = PF03IsolationVal(elec, 0.5, 0);
+        iso_2_ = PF03IsolationVal(muon, 0.5, 0);
+        mva_1_ = elec->GetIdIso("mvaNonTrigV025nsPHYS14");
+      }
+      mva_2_ = 0.0;
       emu_dxy_1_ = -1. * elec->dxy_vertex();
+      d0_1_ = emu_dxy_1_;
       emu_dxy_2_ = -1. * muon->dxy_vertex();
+      d0_2_ = emu_dxy_2_;
     }
 
     l1_met_ = 0.0;
@@ -326,6 +704,7 @@ namespace ic {
     if (n_jets_ >= 1) {
       jpt_1_ = jets[0]->pt();
       jeta_1_ = jets[0]->eta();
+      jphi_1_ = jets[0]->phi();
       std::vector<ic::Tau *> taus = event->GetPtrVec<Tau>("taus");
       std::vector<ic::Jet *> leadjet = { jets[0] };
       std::vector<std::pair<ic::Jet *, ic::Tau *>> matches = MatchByDR(leadjet, taus, 0.5, true, true);
@@ -337,11 +716,13 @@ namespace ic {
     } else {
       jpt_1_ = -9999;
       jeta_1_ = -9999;
+      jphi_1_ = -9999;
     }
 
     if (n_jets_ >= 2) {
       jpt_2_ = jets[1]->pt();
       jeta_2_ = jets[1]->eta();
+      jphi_2_ = jets[1]->phi();
       mjj_ = (jets[0]->vector() + jets[1]->vector()).M();
       jdeta_ = fabs(jets[0]->eta() - jets[1]->eta());
       double eta_high = (jets[0]->eta() > jets[1]->eta()) ? jets[0]->eta() : jets[1]->eta();
@@ -355,6 +736,7 @@ namespace ic {
     } else {
       jpt_2_ = -9999;
       jeta_2_ = -9999;
+      jphi_2_ = -9999;
       mjj_ = -9999;
       jdeta_ = -9999;
       n_jetsingap_ = 9999;
@@ -380,9 +762,11 @@ namespace ic {
     if (n_bjets_ >= 1) {
       bpt_1_ = bjets[0]->pt();
       beta_1_ = bjets[0]->eta();
+      bphi_1_ = bjets[0]->phi();
     } else {
       bpt_1_ = -9999;
       beta_1_ = -9999;
+      bphi_1_ = -9999;
     }
 
     if (jets_csv.size() >= 1) {
@@ -597,12 +981,18 @@ namespace ic {
     }
     
     if (write_tree_) outtree_->Fill();
+    if (make_sync_ntuple_) synctree_->Fill();
 
 
     return 0;
   }
 
   int HTTCategories::PostAnalysis() {
+    if(make_sync_ntuple_) {   
+      lOFile->cd();
+      synctree_->Write();
+      lOFile->Close();
+    }
     return 0;
   }
 

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -535,60 +535,60 @@ namespace ic {
     n_vtx_ = eventInfo->good_vertices();
 
     if (event->Exists("svfitMass")) {
-      m_sv_ = {event->Get<double>("svfitMass"),event->Get<float>("svfitMass") };
+      m_sv_ = event->Get<double>("svfitMass");
     } else {
-      m_sv_ = {-9999, -9999};
+      m_sv_ = -9999;
     }
 
     if (event->Exists("svfitHiggs")) {
       Candidate const& higgs = event->Get<Candidate>("svfitHiggs");
-      pt_h_ = {higgs.pt(), static_cast<float>(higgs.pt())};
+      pt_h_ = higgs.pt();
       eta_h_ = higgs.eta();
       phi_h_ = higgs.phi();
     } else {
-      pt_h_ = {-9999, -9999};
+      pt_h_ = -9999;
       eta_h_ = -9999;
       phi_h_ = -9999;
     }
 
-    pt_tt_ = {(ditau->vector() + met->vector()).pt(), static_cast<float>((ditau->vector() + met->vector()).pt())};
-    m_vis_ = {ditau->M(), static_cast<float>(ditau->M())};
+    pt_tt_ = (ditau->vector() + met->vector()).pt();
+    m_vis_ = ditau->M();
    
 
     // This is the HCP hack for the em channel
     // to better align the data with the embedded
     // mass.  
     if (channel_ == channel::em) {
-      m_sv_ = {m_sv_.var_double * mass_shift_, static_cast<float>(m_sv_.var_double * mass_shift_)};
-      m_vis_ = {m_vis_.var_double * mass_shift_, static_cast<float>(m_vis_.var_double * mass_shift_)};
+      m_sv_ = m_sv_ * mass_shift_;
+      m_vis_ = m_vis_* mass_shift_;
       em_gf_mva_ = event->Exists("em_gf_mva") ? event->Get<double>("em_gf_mva") : 0.;
       // em_vbf_mva_ = event->Exists("em_vbf_mva") ? event->Get<double>("em_vbf_mva") : 0.;
     }
     if (event->Exists("mass_scale")) {
-      m_sv_ = {m_sv_.var_double * event->Get<double>("mass_scale"),static_cast<float>(m_sv_.var_double * event->Get<double>("mass_scale")) };
-      m_vis_ = {m_vis_.var_double * event->Get<double>("mass_scale"),static_cast<float>(m_vis_.var_double * event->Get<double>("mass_scale")) };
+      m_sv_ = m_sv_ * event->Get<double>("mass_scale");
+      m_vis_ = m_vis_* event->Get<double>("mass_scale");
     }
 
-    mt_1_ = {MT(lep1, met), static_cast<float>(MT(lep1, met))};
+    mt_1_ = MT(lep1, met);
     mt_2_ = MT(lep2, met);
     mt_ll_ = MT(ditau, met);
-    pzeta_ = {PZeta(ditau, met, 0.85), static_cast<float>(PZeta(ditau, met, 0.85))};
-    pzetavis_ = {PZetaVis(ditau), static_cast<float>(PZetaVis(ditau))};
-    pzetamiss_ = {PZeta(ditau, met, 0.0), static_cast<float>(PZeta(ditau, met, 0.0))};
+    pzeta_ = PZeta(ditau, met, 0.85);
+    pzetavis_ = PZetaVis(ditau);
+    pzetamiss_ = PZeta(ditau, met, 0.0);
     emu_dphi_ = std::fabs(ROOT::Math::VectorUtil::DeltaPhi(lep1->vector(), lep2->vector()));
 
-    pt_1_= {lep1->pt(), static_cast<float>(lep1->pt())};
-    pt_2_ = {lep2->pt(), static_cast<float>(lep2->pt())};
-    eta_1_ = {lep1->eta(), static_cast<float>(lep1->eta())};
-    eta_2_ = {lep2->eta(), static_cast<float>(lep2->eta())};
+    pt_1_ = lep1->pt();
+    pt_2_ = lep2->pt();
+    eta_1_ = lep1->eta();
+    eta_2_ = lep2->eta();
     phi_1_ = lep1->phi();
     phi_2_ = lep2->phi();
     m_1_ = lep1->M();
-    m_2_ = {lep2->M(), static_cast<float>(lep2->M())};
+    m_2_ = lep2->M();
     q_1_ = lep1->charge();
     q_2_ = lep2->charge();
-    met_ = {met->pt(), static_cast<float>(met->pt())};
-    met_phi_ = {met->phi(), static_cast<float>(met->phi())};
+    met_ = met->pt();
+    met_phi_ = met->phi();
 
     metCov00_ = met->xx_sig();
     metCov10_ = met->yx_sig();
@@ -698,8 +698,8 @@ namespace ic {
     n_loose_bjets_ = loose_bjets.size();
 
     if (n_jets_ >= 1) {
-      jpt_1_ = {jets[0]->pt(), static_cast<float>(jets[0]->pt())};
-      jeta_1_ = {jets[0]->eta(), static_cast<float>(jets[0]->eta())};
+      jpt_1_ = jets[0]->pt();
+      jeta_1_ = jets[0]->eta();
       jphi_1_ = jets[0]->phi();
       std::vector<ic::Tau *> taus = event->GetPtrVec<Tau>("taus");
       std::vector<ic::Jet *> leadjet = { jets[0] };
@@ -710,17 +710,17 @@ namespace ic {
         j1_dm_ = -1;
       }
     } else {
-      jpt_1_ = {-9999,-9999};
-      jeta_1_ = {-9999,-9999};
+      jpt_1_ = -9999;
+      jeta_1_ = -9999;
       jphi_1_ = -9999;
     }
 
     if (n_jets_ >= 2) {
-      jpt_2_ = {jets[1]->pt(),static_cast<float>(jets[1]->pt())};
-      jeta_2_ = {jets[1]->eta(),static_cast<float>(jets[1]->eta())};
+      jpt_2_ = jets[1]->pt();
+      jeta_2_ = jets[1]->eta();
       jphi_2_ = jets[1]->phi();
-      mjj_ = {(jets[0]->vector() + jets[1]->vector()).M(), static_cast<float>((jets[0]->vector() + jets[1]->vector()).M())};
-      jdeta_ = {fabs(jets[0]->eta() - jets[1]->eta()), static_cast<float>(fabs(jets[0]->eta() - jets[1]->eta()))};
+      mjj_ = (jets[0]->vector() + jets[1]->vector()).M();
+      jdeta_ = fabs(jets[0]->eta() - jets[1]->eta());
       double eta_high = (jets[0]->eta() > jets[1]->eta()) ? jets[0]->eta() : jets[1]->eta();
       double eta_low = (jets[0]->eta() > jets[1]->eta()) ? jets[1]->eta() : jets[0]->eta();
       n_jetsingap_ = 0;
@@ -730,11 +730,11 @@ namespace ic {
         }
       }
     } else {
-      jpt_2_ = {-9999,-9999};
-      jeta_2_ = {-9999,-9999};
+      jpt_2_ = -9999;
+      jeta_2_ = -9999;
       jphi_2_ = -9999;
-      mjj_ = {-9999,-9999};
-      jdeta_ = {-9999, -9999};
+      mjj_ = -9999;
+      jdeta_ = -9999;
       n_jetsingap_ = 9999;
     }
 
@@ -756,12 +756,12 @@ namespace ic {
     }
 
     if (n_bjets_ >= 1) {
-      bpt_1_ = {bjets[0]->pt(), static_cast<float>(bjets[0]->pt())};
-      beta_1_ = {bjets[0]->eta(), static_cast<float>(bjets[0]->eta())};
+      bpt_1_ = bjets[0]->pt();
+      beta_1_ = bjets[0]->eta();
       bphi_1_ = bjets[0]->phi();
     } else {
-      bpt_1_ = {-9999,-9999};
-      beta_1_ = {-9999,-9999};
+      bpt_1_ = -9999;
+      beta_1_ = -9999;
       bphi_1_ = -9999;
     }
 
@@ -976,7 +976,7 @@ namespace ic {
       mbb_h_ = -9999;
     }
     
-    if (write_tree_) outtree_->Fill();
+    if (write_tree_ && fs_) outtree_->Fill();
     if (make_sync_ntuple_) synctree_->Fill();
 
 

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -360,15 +360,15 @@ namespace ic {
       // phi
       synctree_->Branch("jphi_1", &jphi_1_, "jphi_1/F");
       // raw pt (before JEC)
-//      synctree_->Branch("jptraw_1", &lJPtRaw1, "lJPtRaw1/F");
+      synctree_->Branch("jptraw_1", &jptraw_1_, "jptraw_1/F");
       // pt uncertainty relative to corrected pt (not in IC ntuples)
-//      synctree_->Branch("jptunc_1", &lJPtUnc1, "lJPtUnc1/F");
+      synctree_->Branch("jptunc_1", &jptunc_1_, "jptunc_1/F");
       // Pileup ID MVA output
-//      synctree_->Branch("jmva_1", &lJMVA1, "lJMVA1/F");
+      synctree_->Branch("jmva_1", &jmva_1_, "jmva_1/F");
       // Linear radial moment (not used in htt analysis)
-//      synctree_->Branch("jlrm_1", &lLRM1, "lLRM1/F");
+      synctree_->Branch("jlrm_1", &jlrm_1_, "jlrm_1/F");
       // Charged track multiplicity (not used in htt analysis)
-//      synctree_->Branch("jctm_1", &lCTM1, "lCTM1/I");
+      synctree_->Branch("jctm_1", &jctm_1_, "jctm_1/I");
 
       // Sub-leading Jet
       // pt
@@ -378,15 +378,15 @@ namespace ic {
       // phi
       synctree_->Branch("jphi_2", &jphi_2_, "jphi_2/F");
       // raw pt (before JEC)
-//      synctree_->Branch("jptraw_2", &lJPtRaw2, "lJPtRaw2/F");
+      synctree_->Branch("jptraw_2", &jptraw_2_, "jptraw_2/F");
       // pt uncertainty relative to corrected pt (not in IC ntuples)
-//      synctree_->Branch("jptunc_2", &lJPtUnc2, "lJPtUnc2/F");
+      synctree_->Branch("jptunc_2", &jptunc_2_, "jptunc_2/F");
       // Pileup ID MVA output
-//      synctree_->Branch("jmva_2", &lJMVA2, "lJMVA2/F");
+      synctree_->Branch("jmva_2", &jmva_2_, "jmva_2/F");
       // Linear radial moment (not used in htt analysis)
-//      synctree_->Branch("jlrm_2", &lLRM2, "lLRM2/F");
+      synctree_->Branch("jlrm_2", &jlrm_2_, "jlrm_2/F");
       // Charged track multiplicity (not used in htt analysis)
-//      synctree_->Branch("jctm_2", &lCTM2, "lCTM2/I");
+      synctree_->Branch("jctm_2", &jctm_2_, "jctm_2/I");
 
       // Di-jet properties
       // Calculated with leading and sub-leading jets when njets >= 2
@@ -396,7 +396,7 @@ namespace ic {
       synctree_->Branch("jdeta", &jdeta_.var_float, "jdeta/F");
       // number of jets, passing above selections, in pseudorapidity gap
       // between jets
-//      synctree_->Branch("njetingap", &lNJetInGap, "lNJetInGap/I");
+      synctree_->Branch("njetingap", &n_jetsingap_, "n_jetsingap/I");
 
       // B-Tagged Jet properties
       // The following properties are for the leading (in pt) CSV medium b-tagged
@@ -701,6 +701,11 @@ namespace ic {
       jpt_1_ = jets[0]->pt();
       jeta_1_ = jets[0]->eta();
       jphi_1_ = jets[0]->phi();
+      jptraw_1_ = jets[0]->uncorrected_energy() * (jets[0]->pt() / jets[0]->energy());
+      jptunc_1_ = 0.0;
+      jmva_1_ = jets[0]->pu_id_mva_value();
+      jlrm_1_ = jets[0]->linear_radial_moment();
+      jctm_1_ = jets[0]->charged_multiplicity_nopu();
       std::vector<ic::Tau *> taus = event->GetPtrVec<Tau>("taus");
       std::vector<ic::Jet *> leadjet = { jets[0] };
       std::vector<std::pair<ic::Jet *, ic::Tau *>> matches = MatchByDR(leadjet, taus, 0.5, true, true);
@@ -713,12 +718,22 @@ namespace ic {
       jpt_1_ = -9999;
       jeta_1_ = -9999;
       jphi_1_ = -9999;
+      jptraw_1_ = -9999;
+      jptunc_1_ = -9999;
+      jmva_1_ = -9999;
+      jlrm_1_ = -9999;
+      jctm_1_ = -9999;
     }
 
     if (n_jets_ >= 2) {
       jpt_2_ = jets[1]->pt();
       jeta_2_ = jets[1]->eta();
       jphi_2_ = jets[1]->phi();
+      jptraw_2_ = jets[1]->uncorrected_energy() * (jets[1]->pt() / jets[1]->energy());
+      jptunc_2_ = 0.0;
+      jmva_2_ = jets[1]->pu_id_mva_value();
+      jlrm_2_ = jets[1]->linear_radial_moment();
+      jctm_2_ = jets[1]->charged_multiplicity_nopu();
       mjj_ = (jets[0]->vector() + jets[1]->vector()).M();
       jdeta_ = fabs(jets[0]->eta() - jets[1]->eta());
       double eta_high = (jets[0]->eta() > jets[1]->eta()) ? jets[0]->eta() : jets[1]->eta();
@@ -735,6 +750,11 @@ namespace ic {
       jphi_2_ = -9999;
       mjj_ = -9999;
       jdeta_ = -9999;
+      jptraw_2_ = -9999;
+      jptunc_2_ = -9999;
+      jmva_2_ = -9999;
+      jlrm_2_ = -9999;
+      jctm_2_ = -9999;
       n_jetsingap_ = 9999;
     }
 

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -709,6 +709,22 @@ namespace ic {
       emu_dxy_2_ = -1. * muon->dxy_vertex();
       d0_2_ = static_cast<float>(emu_dxy_2_);
     }
+    if (channel_ == channel::tt) {
+      Tau const* tau1 = dynamic_cast<Tau const*>(lep1);
+      Tau const* tau2 = dynamic_cast<Tau const*>(lep2);
+//        l3Hits_2 = tau->HasTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits") ? tau->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits") : 0. ;
+//        lagainstElectronMVA3raw_2 = tau->HasTauID("againstElectronMVA3raw") ? tau->GetTauID("againstElectronMVA3raw") : 0. ;
+//        lbyIsolationMVA2raw_2 = tau->HasTauID("byIsolationMVA2raw") ? tau->GetTauID("byIsolationMVA2raw") : 0. ;
+//        lagainstMuonLoose2_2 = tau->HasTauID("againstMuonLoose2") ? tau->GetTauID("againstMuonLoose2") : 0. ;
+//        lagainstMuonMedium2_2 = tau->HasTauID("againstMuonMedium2") ? tau->GetTauID("againstMuonMedium2") : 0. ;
+ //       lagainstMuonTight2_2 = tau->HasTauID("againstMuonTight2") ? tau->GetTauID("againstMuonTight2") : 0. ;
+      if(strategy_ == strategy::phys14) {
+        iso_1_ = tau1->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits");
+        mva_1_ = tau1->GetTauID("againstElectronMVA5raw");
+        iso_2_ = tau2->GetTauID("byCombinedIsolationDeltaBetaCorrRaw3Hits");
+        mva_2_ = tau2->GetTauID("againstElectronMVA5raw");
+      }
+    }
 
 
     Tau const* tau = dynamic_cast<Tau const*>(lep2);

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -290,7 +290,11 @@ namespace ic {
       synctree_->Branch("mt_2", &mt_2_, "mt_2/F");
 
       // Whether event is os or ss
-      synctree_->Branch("os", &os_, "os/B");  
+      synctree_->Branch("os", &os_, "os/B");
+      // Whether event passes lepton vetos. TRUE = event is vetoed.  
+      synctree_->Branch("dilepton_veto", &dilepton_veto_, "dilepton_veto/B");
+      synctree_->Branch("extraelec_veto", &extraelec_veto_, "extraelec_veto/B");
+      synctree_->Branch("extramuon_veto", &extramuon_veto_, "extramuon_veto/B");
 
       // Variables defined when lepton 2 is a tau
       // raw value of the 3hits delta-beta isolation
@@ -534,6 +538,29 @@ namespace ic {
     } else {
       os_ = false;
     }
+    //Fill extra lepton veto bools
+    dilepton_veto_ = false;
+    extraelec_veto_ = false;
+    extramuon_veto_ = false;
+    if(channel_ == channel::et) { 
+        if(event->Exists("dielec_veto")) dilepton_veto_ = event->Get<bool>("dielec_veto");
+        if(event->Exists("extra_elec_veto")) extraelec_veto_ = event->Get<bool>("extra_elec_veto");
+        if(event->Exists("extra_muon_veto")) extramuon_veto_ = event->Get<bool>("extra_muon_veto");
+    }
+    if(channel_ == channel::mt) { 
+        if(event->Exists("dimuon_veto")) dilepton_veto_ = event->Get<bool>("dimuon_veto");
+        if(event->Exists("extra_elec_veto")) extraelec_veto_ = event->Get<bool>("extra_elec_veto");
+        if(event->Exists("extra_muon_veto")) extramuon_veto_ = event->Get<bool>("extra_muon_veto");
+    }
+    if(channel_ == channel::em) { 
+        if(event->Exists("extra_elec_veto")) extraelec_veto_ = event->Get<bool>("extra_elec_veto");
+        if(event->Exists("extra_muon_veto")) extramuon_veto_ = event->Get<bool>("extra_muon_veto");
+    }
+    if(channel_ == channel::tt) {
+        if(event->Exists("extra_elec_veto")) extraelec_veto_ = event->Get<bool>("extra_elec_veto");
+        if(event->Exists("extra_muon_veto")) extramuon_veto_ = event->Get<bool>("extra_muon_veto");
+    }
+
 
     n_vtx_ = eventInfo->good_vertices();
 

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -53,7 +53,7 @@ namespace ic {
 
     if (fs_ && write_tree_) {
       outtree_ = fs_->make<TTree>("ntuple","ntuple");
-      outtree_->Branch("wt",                &wt_);
+      outtree_->Branch("wt",                &wt_.var_double);
       outtree_->Branch("wt_ggh_pt_up",      &wt_ggh_pt_up_);
       outtree_->Branch("wt_ggh_pt_down",    &wt_ggh_pt_down_);
       outtree_->Branch("wt_tau_fake_up",    &wt_tau_fake_up_);
@@ -64,21 +64,21 @@ namespace ic {
       outtree_->Branch("wt_tau_id_down",    &wt_tau_id_down_);
       outtree_->Branch("os",                &os_);
       outtree_->Branch("n_vtx",             &n_vtx_);
-      outtree_->Branch("m_sv",              &m_sv_);
-      outtree_->Branch("m_vis",             &m_vis_);
-      outtree_->Branch("pt_h",              &pt_h_);
-      outtree_->Branch("pt_tt",             &pt_tt_);
-      outtree_->Branch("mt_1",              &mt_1_);
-      outtree_->Branch("pzeta",             &pzeta_);
-      outtree_->Branch("pt_1",              &pt_1_);
-      outtree_->Branch("pt_2",              &pt_2_);
-      outtree_->Branch("eta_1",             &eta_1_);
-      outtree_->Branch("eta_2",             &eta_2_);
+      outtree_->Branch("m_sv",              &m_sv_.var_double);
+      outtree_->Branch("m_vis",             &m_vis_.var_double);
+      outtree_->Branch("pt_h",              &pt_h_.var_double);
+      outtree_->Branch("pt_tt",             &pt_tt_.var_double);
+      outtree_->Branch("mt_1",              &mt_1_.var_double);
+      outtree_->Branch("pzeta",             &pzeta_.var_double);
+      outtree_->Branch("pt_1",              &pt_1_.var_double);
+      outtree_->Branch("pt_2",              &pt_2_.var_double);
+      outtree_->Branch("eta_1",             &eta_1_.var_double);
+      outtree_->Branch("eta_2",             &eta_2_.var_double);
       outtree_->Branch("iso_2",             &iso_2_);
       outtree_->Branch("z_2",               &z_2_);
-      outtree_->Branch("m_2",               &m_2_);
-      outtree_->Branch("met",               &met_);
-      outtree_->Branch("met_phi",           &met_phi_);
+      outtree_->Branch("m_2",               &m_2_.var_double);
+      outtree_->Branch("met",               &met_.var_double);
+      outtree_->Branch("met_phi",           &met_phi_.var_double);
       outtree_->Branch("tau_decay_mode",    &tau_decay_mode_);
       outtree_->Branch("n_jets",            &n_jets_);
       outtree_->Branch("n_lowpt_jets",      &n_lowpt_jets_);
@@ -88,13 +88,13 @@ namespace ic {
       outtree_->Branch("n_bjets_csv",       &n_bjets_csv_);
       outtree_->Branch("n_loose_bjets",     &n_loose_bjets_);
       outtree_->Branch("n_jetsingap",       &n_jetsingap_);
-      outtree_->Branch("jpt_1",             &jpt_1_);
+      outtree_->Branch("jpt_1",             &jpt_1_.var_double);
       outtree_->Branch("j1_dm",             &j1_dm_);
-      outtree_->Branch("jpt_2",             &jpt_2_);
-      outtree_->Branch("jeta_1",            &jeta_1_);
-      outtree_->Branch("jeta_2",            &jeta_2_);
-      outtree_->Branch("bpt_1",             &bpt_1_);
-      outtree_->Branch("beta_1",            &beta_1_);
+      outtree_->Branch("jpt_2",             &jpt_2_.var_double);
+      outtree_->Branch("jeta_1",            &jeta_1_.var_double);
+      outtree_->Branch("jeta_2",            &jeta_2_.var_double);
+      outtree_->Branch("bpt_1",             &bpt_1_.var_double);
+      outtree_->Branch("beta_1",            &beta_1_.var_double);
       outtree_->Branch("bcsv_1",            &bcsv_1_);
       outtree_->Branch("jet_csvpt_1",       &jet_csvpt_1_);
       outtree_->Branch("jet_csvEt_1",       &jet_csvEt_1_);
@@ -105,7 +105,7 @@ namespace ic {
       outtree_->Branch("jet_csv_dR",		  &jet_csv_dR_);
       outtree_->Branch("jet_csveta_2",      &jet_csveta_2_);
       outtree_->Branch("jet_csvbcsv_2",     &jet_csvbcsv_2_);
-      outtree_->Branch("mjj",               &mjj_);
+      outtree_->Branch("mjj",               &mjj_.var_double);
       outtree_->Branch("mjj_h",             &mjj_h_);
       outtree_->Branch("mbb_h",             &mbb_h_);
       outtree_->Branch("mjj_tt",            &mjj_tt_);
@@ -130,7 +130,7 @@ namespace ic {
       outtree_->Branch("m_bb_chi2",     &m_bb_chi2_);
       outtree_->Branch("pull_balance_bb", &pull_balance_bb_);
       outtree_->Branch("convergence_bb", &convergence_bb_);
-      outtree_->Branch("jdeta",             &jdeta_);
+      outtree_->Branch("jdeta",             &jdeta_.var_double);
       outtree_->Branch("jet_csv_mjj",               &jet_csv_mjj_);
       outtree_->Branch("jet_csv_dphi",               &jet_csv_dphi_);
       outtree_->Branch("jet_csv_deta",             &jet_csv_deta_);
@@ -138,13 +138,11 @@ namespace ic {
       outtree_->Branch("mjj_lowpt",         &mjj_lowpt_);
       outtree_->Branch("jdeta_lowpt",       &jdeta_lowpt_);
       outtree_->Branch("n_jetsingap_lowpt", &n_jetsingap_lowpt_);
-      outtree_->Branch("l1_met",            &l1_met_);
-      outtree_->Branch("calo_nohf_met",     &calo_nohf_met_);
       if (channel_ == channel::em) {
         outtree_->Branch("em_gf_mva",         &em_gf_mva_);
         // outtree_->Branch("em_vbf_mva",        &em_vbf_mva_);
-        outtree_->Branch("pzetavis",          &pzetavis_);
-        outtree_->Branch("pzetamiss",         &pzetamiss_);
+        outtree_->Branch("pzetavis",          &pzetavis_.var_double);
+        outtree_->Branch("pzetamiss",         &pzetamiss_.var_double);
         outtree_->Branch("mt_ll",             &mt_ll_);
         outtree_->Branch("emu_dphi",          &emu_dphi_);
         outtree_->Branch("emu_csv",           &emu_csv_);
@@ -153,7 +151,7 @@ namespace ic {
       }
     }
     if(make_sync_ntuple_) {
-      //Due to the possibility of other groups requesting different branch names/branch contents
+      //Fue to the possibility of other groups requesting different branch names/branch contents
       //we have to make an alternative (albeit very similar) TTree for the sync ntuple. 
       lOFile = new TFile(sync_output_name_.c_str(), "RECREATE");
       lOFile->cd();
@@ -220,14 +218,14 @@ namespace ic {
       synctree_->Branch("signalWeight", &signalweight_, "signalweight/F");
       // Total combined event weight (excluding lumi weighting)
       // NB: may contain weights not included in the above
-      synctree_->Branch("weight", &wt_, "wt/F");
+      synctree_->Branch("weight", &wt_.var_float, "wt/F");
 
       // Visible di-tau mass
-      synctree_->Branch("m_vis", &m_vis_, "m_vis/F");
+      synctree_->Branch("m_vis", &m_vis_.var_float, "m_vis/F");
       // SVFit di-tau mass
-      synctree_->Branch("m_sv", &m_sv_, "m_sv/F");
+      synctree_->Branch("m_sv", &m_sv_.var_float, "m_sv/F");
       // SVFit di-tau pt (only for Markov-Chain SVFit)
-      synctree_->Branch("pt_sv", &pt_h_, "pt_h/F");
+      synctree_->Branch("pt_sv", &pt_h_.var_float, "pt_h/F");
       // SVFit di-tau eta (only for Markov-Chain SVFit)
       synctree_->Branch("eta_sv", &eta_h_, "eta_h/F");
       // SVFit di-tau phi (only for Markov-Chain SVFit)
@@ -235,11 +233,11 @@ namespace ic {
 
       // Lepton 1 properties
       // pt (including effect of any energy scale corrections)
-      synctree_->Branch("pt_1", &pt_1_, "pt_1/F");
+      synctree_->Branch("pt_1", &pt_1_.var_float, "pt_1/F");
       // phi
       synctree_->Branch("phi_1", &phi_1_, "phi_1/F");
       // eta
-      synctree_->Branch("eta_1", &eta_1_, "eta_1/F");
+      synctree_->Branch("eta_1", &eta_1_.var_float, "eta_1/F");
       // mass
       synctree_->Branch("m_1", &m_1_, "m_1/F");
       // charge
@@ -260,17 +258,17 @@ namespace ic {
       // Whether lepton passes iso selection (always true in IC ntuples)
 //      synctree_->Branch("passiso_1", &lPassIso1, "lPassIso1/B");
       // Transverse mass of lepton 1 and MVA MET
-      synctree_->Branch("mt_1", &mt_1_, "mt_1/F");
+      synctree_->Branch("mt_1", &mt_1_.var_float, "mt_1/F");
 
       // Lepton 2 properties
       // pt (including effect of any energy scale corrections)
-      synctree_->Branch("pt_2", &pt_2_, "pt_2/F");
+      synctree_->Branch("pt_2", &pt_2_.var_float, "pt_2/F");
       // phi
-      synctree_->Branch("phi_2", &phi_2_, "lPhi2/F");
+      synctree_->Branch("phi_2", &phi_2_, "phi_2/F");
       // eta
-      synctree_->Branch("eta_2", &eta_2_, "lEta2/F");
+      synctree_->Branch("eta_2", &eta_2_.var_float, "eta_2/F");
       // mass
-      synctree_->Branch("m_2", &m_2_, "lM2/F");
+      synctree_->Branch("m_2", &m_2_.var_float, "lM2/F");
       // charge
       synctree_->Branch("q_2", &q_2_, "lq2/I");
       // delta-beta corrected isolation (relative or absolute as appropriate)
@@ -323,9 +321,9 @@ namespace ic {
       synctree_->Branch("metcov11", &pfmetCov11_, "pfmetCov11/F");
 
       // MVA MET
-      synctree_->Branch("mvamet", &met_, "met/F");
+      synctree_->Branch("mvamet", &met_.var_float, "met/F");
       // MVA MET phi
-      synctree_->Branch("mvametphi", &met_phi_, "met_phi/F");
+      synctree_->Branch("mvametphi", &met_phi_.var_float, "met_phi/F");
       // Elements of the MVA MET covariance matrix
       synctree_->Branch("mvacov00", &metCov00_, "metCov00/F");
       synctree_->Branch("mvacov01", &metCov01_, "metCov01/F");
@@ -333,12 +331,12 @@ namespace ic {
       synctree_->Branch("mvacov11", &metCov11_, "metCov11/F");
 
       // pt of the di-tau + MET system
-      synctree_->Branch("pt_tt", &pt_tt_, "pt_tt/F");
+      synctree_->Branch("pt_tt", &pt_tt_.var_float, "pt_tt/F");
 
       // Visible pzeta
-      synctree_->Branch("pzetavis", &pzetavis_, "pzetavis/F");
+      synctree_->Branch("pzetavis", &pzetavis_.var_float, "pzetavis/F");
       // MET pzeta
-      synctree_->Branch("pzetamiss", &pzetamiss_, "pzetamiss/F");
+      synctree_->Branch("pzetamiss", &pzetamiss_.var_float, "pzetamiss/F");
       // ttbar-rejection MVA output (emu channel only)
       synctree_->Branch("mva_gf", &em_gf_mva_, "em_gf_mva/F");
 
@@ -352,13 +350,13 @@ namespace ic {
       synctree_->Branch("njets", &n_jets_, "n_jets_/I");
       // Number of jets passing above selection but with
       // pt > 20 instead of pt > 30
-//      synctree_->Branch("njetspt20", &lNJetsPt20, "lNJetsPt20/I");
+      synctree_->Branch("njetspt20", &n_lowpt_jets_, "n_lowpt_jets/I");
 
       // Leading Jet
       // pt
-      synctree_->Branch("jpt_1", &jpt_1_, "jpt_1/F");
+      synctree_->Branch("jpt_1", &jpt_1_.var_float, "jpt_1/F");
       // eta
-      synctree_->Branch("jeta_1", &jeta_1_, "jeta_1/F");
+      synctree_->Branch("jeta_1", &jeta_1_.var_float, "jeta_1/F");
       // phi
       synctree_->Branch("jphi_1", &jphi_1_, "jphi_1/F");
       // raw pt (before JEC)
@@ -374,9 +372,9 @@ namespace ic {
 
       // Sub-leading Jet
       // pt
-      synctree_->Branch("jpt_2", &jpt_2_, "jpt_2/F");
+      synctree_->Branch("jpt_2", &jpt_2_.var_float, "jpt_2/F");
       // eta
-      synctree_->Branch("jeta_2", &jeta_2_, "jeta_2/F");
+      synctree_->Branch("jeta_2", &jeta_2_.var_float, "jeta_2/F");
       // phi
       synctree_->Branch("jphi_2", &jphi_2_, "jphi_2/F");
       // raw pt (before JEC)
@@ -393,9 +391,9 @@ namespace ic {
       // Di-jet properties
       // Calculated with leading and sub-leading jets when njets >= 2
       // di-jet mass
-      synctree_->Branch("mjj", &mjj_, "mjj/F");
+      synctree_->Branch("mjj", &mjj_.var_float, "mjj/F");
       // absolute difference in eta
-      synctree_->Branch("jdeta", &jdeta_, "jdeta/F");
+      synctree_->Branch("jdeta", &jdeta_.var_float, "jdeta/F");
       // number of jets, passing above selections, in pseudorapidity gap
       // between jets
 //      synctree_->Branch("njetingap", &lNJetInGap, "lNJetInGap/I");
@@ -409,9 +407,9 @@ namespace ic {
       // Number of b-tagging jets passing above selections
       synctree_->Branch("nbtag", &n_bjets_, "n_bjets/I");
       // pt
-      synctree_->Branch("bpt", &bpt_1_, "bpt_1/F");
+      synctree_->Branch("bpt", &bpt_1_.var_float, "bpt_1/F");
       // eta
-      synctree_->Branch("beta", &beta_1_, "beta_1/F");
+      synctree_->Branch("beta", &beta_1_.var_float, "beta_1/F");
       // phi
       synctree_->Branch("bphi", &bphi_1_, "bphi_1/F");
     }
@@ -423,7 +421,7 @@ namespace ic {
     // Get the objects we need from the event
     EventInfo const* eventInfo = event->GetPtr<EventInfo>("eventInfo");
 
-    wt_ = eventInfo->total_weight();
+    wt_ = {eventInfo->total_weight(), static_cast<float>(eventInfo->total_weight())};
     run_ = eventInfo->run();
     event_ = eventInfo->event();
     lumi_ = eventInfo->lumi_block();
@@ -537,60 +535,60 @@ namespace ic {
     n_vtx_ = eventInfo->good_vertices();
 
     if (event->Exists("svfitMass")) {
-      m_sv_ = event->Get<double>("svfitMass");
+      m_sv_ = {event->Get<double>("svfitMass"),event->Get<float>("svfitMass") };
     } else {
-      m_sv_ = -9999;
+      m_sv_ = {-9999, -9999};
     }
 
     if (event->Exists("svfitHiggs")) {
       Candidate const& higgs = event->Get<Candidate>("svfitHiggs");
-      pt_h_ = higgs.pt();
+      pt_h_ = {higgs.pt(), static_cast<float>(higgs.pt())};
       eta_h_ = higgs.eta();
       phi_h_ = higgs.phi();
     } else {
-      pt_h_ = -9999;
+      pt_h_ = {-9999, -9999};
       eta_h_ = -9999;
       phi_h_ = -9999;
     }
 
-    pt_tt_ = (ditau->vector() + met->vector()).pt();
-    m_vis_ = ditau->M();
+    pt_tt_ = {(ditau->vector() + met->vector()).pt(), static_cast<float>((ditau->vector() + met->vector()).pt())};
+    m_vis_ = {ditau->M(), static_cast<float>(ditau->M())};
    
 
     // This is the HCP hack for the em channel
     // to better align the data with the embedded
     // mass.  
     if (channel_ == channel::em) {
-      m_sv_ = m_sv_ * mass_shift_;
-      m_vis_ = m_vis_ * mass_shift_;
+      m_sv_ = {m_sv_.var_double * mass_shift_, static_cast<float>(m_sv_.var_double * mass_shift_)};
+      m_vis_ = {m_vis_.var_double * mass_shift_, static_cast<float>(m_vis_.var_double * mass_shift_)};
       em_gf_mva_ = event->Exists("em_gf_mva") ? event->Get<double>("em_gf_mva") : 0.;
       // em_vbf_mva_ = event->Exists("em_vbf_mva") ? event->Get<double>("em_vbf_mva") : 0.;
     }
     if (event->Exists("mass_scale")) {
-      m_sv_ = m_sv_ * event->Get<double>("mass_scale");
-      m_vis_ = m_vis_ * event->Get<double>("mass_scale");
+      m_sv_ = {m_sv_.var_double * event->Get<double>("mass_scale"),static_cast<float>(m_sv_.var_double * event->Get<double>("mass_scale")) };
+      m_vis_ = {m_vis_.var_double * event->Get<double>("mass_scale"),static_cast<float>(m_vis_.var_double * event->Get<double>("mass_scale")) };
     }
 
-    mt_1_ = MT(lep1, met);
+    mt_1_ = {MT(lep1, met), static_cast<float>(MT(lep1, met))};
     mt_2_ = MT(lep2, met);
     mt_ll_ = MT(ditau, met);
-    pzeta_ = PZeta(ditau, met, 0.85);
-    pzetavis_ = PZetaVis(ditau);
-    pzetamiss_ = PZeta(ditau, met, 0.0);
+    pzeta_ = {PZeta(ditau, met, 0.85), static_cast<float>(PZeta(ditau, met, 0.85))};
+    pzetavis_ = {PZetaVis(ditau), static_cast<float>(PZetaVis(ditau))};
+    pzetamiss_ = {PZeta(ditau, met, 0.0), static_cast<float>(PZeta(ditau, met, 0.0))};
     emu_dphi_ = std::fabs(ROOT::Math::VectorUtil::DeltaPhi(lep1->vector(), lep2->vector()));
 
-    pt_1_ = lep1->pt();
-    pt_2_ = lep2->pt();
-    eta_1_ = lep1->eta();
-    eta_2_ = lep2->eta();
+    pt_1_= {lep1->pt(), static_cast<float>(lep1->pt())};
+    pt_2_ = {lep2->pt(), static_cast<float>(lep2->pt())};
+    eta_1_ = {lep1->eta(), static_cast<float>(lep1->eta())};
+    eta_2_ = {lep2->eta(), static_cast<float>(lep2->eta())};
     phi_1_ = lep1->phi();
     phi_2_ = lep2->phi();
     m_1_ = lep1->M();
-    m_2_ = lep2->M();
+    m_2_ = {lep2->M(), static_cast<float>(lep2->M())};
     q_1_ = lep1->charge();
     q_2_ = lep2->charge();
-    met_ = met->pt();
-    met_phi_ = met->phi();
+    met_ = {met->pt(), static_cast<float>(met->pt())};
+    met_phi_ = {met->phi(), static_cast<float>(met->phi())};
 
     metCov00_ = met->xx_sig();
     metCov10_ = met->yx_sig();
@@ -677,13 +675,11 @@ namespace ic {
       }
       mva_2_ = 0.0;
       emu_dxy_1_ = -1. * elec->dxy_vertex();
-      d0_1_ = emu_dxy_1_;
+      d0_1_ = static_cast<float>(emu_dxy_1_);
       emu_dxy_2_ = -1. * muon->dxy_vertex();
-      d0_2_ = emu_dxy_2_;
+      d0_2_ = static_cast<float>(emu_dxy_2_);
     }
 
-    l1_met_ = 0.0;
-    calo_nohf_met_ = 0.0;
 
     Tau const* tau = dynamic_cast<Tau const*>(lep2);
     if (tau) {
@@ -702,8 +698,8 @@ namespace ic {
     n_loose_bjets_ = loose_bjets.size();
 
     if (n_jets_ >= 1) {
-      jpt_1_ = jets[0]->pt();
-      jeta_1_ = jets[0]->eta();
+      jpt_1_ = {jets[0]->pt(), static_cast<float>(jets[0]->pt())};
+      jeta_1_ = {jets[0]->eta(), static_cast<float>(jets[0]->eta())};
       jphi_1_ = jets[0]->phi();
       std::vector<ic::Tau *> taus = event->GetPtrVec<Tau>("taus");
       std::vector<ic::Jet *> leadjet = { jets[0] };
@@ -714,17 +710,17 @@ namespace ic {
         j1_dm_ = -1;
       }
     } else {
-      jpt_1_ = -9999;
-      jeta_1_ = -9999;
+      jpt_1_ = {-9999,-9999};
+      jeta_1_ = {-9999,-9999};
       jphi_1_ = -9999;
     }
 
     if (n_jets_ >= 2) {
-      jpt_2_ = jets[1]->pt();
-      jeta_2_ = jets[1]->eta();
+      jpt_2_ = {jets[1]->pt(),static_cast<float>(jets[1]->pt())};
+      jeta_2_ = {jets[1]->eta(),static_cast<float>(jets[1]->eta())};
       jphi_2_ = jets[1]->phi();
-      mjj_ = (jets[0]->vector() + jets[1]->vector()).M();
-      jdeta_ = fabs(jets[0]->eta() - jets[1]->eta());
+      mjj_ = {(jets[0]->vector() + jets[1]->vector()).M(), static_cast<float>((jets[0]->vector() + jets[1]->vector()).M())};
+      jdeta_ = {fabs(jets[0]->eta() - jets[1]->eta()), static_cast<float>(fabs(jets[0]->eta() - jets[1]->eta()))};
       double eta_high = (jets[0]->eta() > jets[1]->eta()) ? jets[0]->eta() : jets[1]->eta();
       double eta_low = (jets[0]->eta() > jets[1]->eta()) ? jets[1]->eta() : jets[0]->eta();
       n_jetsingap_ = 0;
@@ -734,11 +730,11 @@ namespace ic {
         }
       }
     } else {
-      jpt_2_ = -9999;
-      jeta_2_ = -9999;
+      jpt_2_ = {-9999,-9999};
+      jeta_2_ = {-9999,-9999};
       jphi_2_ = -9999;
-      mjj_ = -9999;
-      jdeta_ = -9999;
+      mjj_ = {-9999,-9999};
+      jdeta_ = {-9999, -9999};
       n_jetsingap_ = 9999;
     }
 
@@ -760,17 +756,17 @@ namespace ic {
     }
 
     if (n_bjets_ >= 1) {
-      bpt_1_ = bjets[0]->pt();
-      beta_1_ = bjets[0]->eta();
+      bpt_1_ = {bjets[0]->pt(), static_cast<float>(bjets[0]->pt())};
+      beta_1_ = {bjets[0]->eta(), static_cast<float>(bjets[0]->eta())};
       bphi_1_ = bjets[0]->phi();
     } else {
-      bpt_1_ = -9999;
-      beta_1_ = -9999;
+      bpt_1_ = {-9999,-9999};
+      beta_1_ = {-9999,-9999};
       bphi_1_ = -9999;
     }
 
-    if (jets_csv.size() >= 1) {
-      bcsv_1_ = jets_csv[0]->GetBDiscriminator(btag_label);
+    if (prebjets.size() >= 1) {
+      bcsv_1_ = prebjets[0]->GetBDiscriminator(btag_label);
     } else {
       bcsv_1_ = -9999;
     }

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -151,6 +151,10 @@ namespace ic {
       }
     }
     if(make_sync_ntuple_) {
+		  if(fs_){ 
+        synctree_ = fs_->make<TTree>("TauCheck","TauCheck");
+			} else{
+
       //Fue to the possibility of other groups requesting different branch names/branch contents
       //we have to make an alternative (albeit very similar) TTree for the sync ntuple. 
       lOFile = new TFile(sync_output_name_.c_str(), "RECREATE");
@@ -158,6 +162,7 @@ namespace ic {
       // Tree should be named "TauCheck" to aid scripts which
       // make comparisons between sync trees
       synctree_ = new TTree("TauCheck", "TauCheck");
+			}
 
       // The sync tree is filled for all events passing the di-lepton
       // selections in each channel. This includes vertex selection,
@@ -1007,7 +1012,7 @@ namespace ic {
   }
 
   int HTTCategories::PostAnalysis() {
-    if(make_sync_ntuple_) {   
+    if(make_sync_ntuple_&&!fs_) {   
       lOFile->cd();
       synctree_->Write();
       lOFile->Close();

--- a/Analysis/HiggsTauTau/src/HTTCategories.cc
+++ b/Analysis/HiggsTauTau/src/HTTCategories.cc
@@ -289,6 +289,9 @@ namespace ic {
       // Transverse mass of lepton 2 and MVA MET
       synctree_->Branch("mt_2", &mt_2_, "mt_2/F");
 
+      // Whether event is os or ss
+      synctree_->Branch("os", &os_, "os/B");  
+
       // Variables defined when lepton 2 is a tau
       // raw value of the 3hits delta-beta isolation
 
@@ -311,9 +314,9 @@ namespace ic {
                      "againstMuonTight2_2/F");
 */
       // Uncorrected PF MET (not used in analysis)
-      synctree_->Branch("met", &pfmet_, "pfmet_/F");
+      synctree_->Branch("met", &pfmet_, "pfmet/F");
       // Uncorrected PF MET phi (not used in analysis)
-      synctree_->Branch("metphi", &pfmet_phi_, "pfmet_phi_/F");
+      synctree_->Branch("metphi", &pfmet_phi_, "pfmet_phi/F");
       // Elements of the PF MET covariance matrix (not used in analysis)
       synctree_->Branch("metcov00", &pfmetCov00_, "pfmetCov00/F");
       synctree_->Branch("metcov01", &pfmetCov01_, "pfmetCov01/F");
@@ -347,7 +350,7 @@ namespace ic {
       // are not counted
 
       // Number of jets passing above selection
-      synctree_->Branch("njets", &n_jets_, "n_jets_/I");
+      synctree_->Branch("njets", &n_jets_, "n_jets/I");
       // Number of jets passing above selection but with
       // pt > 20 instead of pt > 30
       synctree_->Branch("njetspt20", &n_lowpt_jets_, "n_lowpt_jets/I");

--- a/Analysis/HiggsTauTau/src/HTTFilter.cc
+++ b/Analysis/HiggsTauTau/src/HTTFilter.cc
@@ -1,0 +1,5 @@
+#include "UserCode/ICHiggsTauTau/Analysis/HiggsTauTau/interface/HTTFilter.h"
+
+namespace ic {
+
+}

--- a/Analysis/HiggsTauTau/src/HTTSequence.cc
+++ b/Analysis/HiggsTauTau/src/HTTSequence.cc
@@ -64,12 +64,17 @@ HTTSequence::HTTSequence(std::string& chan, std::string& var, std::string postf,
   output_name=chan + "_" +output_name +  "_" + var + "_" + postf + ".root";
   special_mode=json["special_mode"].asUInt();
   if (special_mode > 0) output_name = "Special_"+boost::lexical_cast<std::string>(special_mode)+"_" + output_name;
-	if(json["make_sync_ntuple"].asBool()){
-	  output_folder="HTTSequenceSyncfilesNEW/";
-		output_name="SYNCFILE"+output_name;
-	}
-  fs = std::make_shared<fwlite::TFileService>(
+  //if(json["make_sync_ntuple"].asBool()) {
+//	output_folder="HTTSequenceSyncfilesNEW/";
+ //   output_name="SYNCFILE"+output_name;
+ // }
+  if(!json["make_sync_ntuple"].asBool()) {
+      fs = std::make_shared<fwlite::TFileService>(
        (output_folder+output_name).c_str());
+  } else {
+      // do not create output file when making sync ntuples
+      fs = NULL;
+  }
   js = json;
   channel_str = chan;
   jes_mode=json["baseline"]["jes_mode"].asUInt();

--- a/Analysis/HiggsTauTau/src/HTTSequence.cc
+++ b/Analysis/HiggsTauTau/src/HTTSequence.cc
@@ -736,8 +736,11 @@ if(strategy_type != strategy::phys14){
     .set_jets_label(jets_label)
     .set_kinfit_mode(kinfit_mode)
     .set_bjet_regression(bjet_regr_correction)
+    .set_make_sync_ntuple(js["make_sync_ntuple"].asBool())
+    .set_sync_output_name("HTTSequenceSyncfilesNEW/SYNCFILE"+output_name)
     .set_mass_shift(mass_shift)
-    .set_write_tree(true));
+    .set_is_embedded(is_embedded)
+    .set_write_tree(!js["make_sync_ntuple"].asBool()));
 
 }
 

--- a/Analysis/HiggsTauTau/src/HTTSequence.cc
+++ b/Analysis/HiggsTauTau/src/HTTSequence.cc
@@ -535,7 +535,7 @@ if(strategy_type != strategy::phys14){
     .set_scale_met_for_tau((tau_scale_mode > 0 || (moriond_tau_scale && (is_embedded || !is_data) )   ))
     .set_tau_scale(tau_shift)
     .set_use_most_isolated(strategy_type == strategy::phys14)
-    .set_use_os_preference(strategy_type == strategy::phys14)
+    .set_use_os_preference(!(strategy_type == strategy::phys14))
     .set_allowed_tau_modes(allowed_tau_modes));
 
 

--- a/Analysis/HiggsTauTau/src/HTTSequence.cc
+++ b/Analysis/HiggsTauTau/src/HTTSequence.cc
@@ -737,7 +737,6 @@ if(strategy_type != strategy::phys14){
     .set_kinfit_mode(kinfit_mode)
     .set_bjet_regression(bjet_regr_correction)
     .set_mass_shift(mass_shift)
-    .set_write_plots(true)
     .set_write_tree(true));
 
 }

--- a/Analysis/HiggsTauTau/src/HTTSequence.cc
+++ b/Analysis/HiggsTauTau/src/HTTSequence.cc
@@ -534,6 +534,8 @@ if(strategy_type != strategy::phys14){
     .set_gen_taus_label(is_embedded ? "genParticlesEmbedded" : "genParticlesTaus")
     .set_scale_met_for_tau((tau_scale_mode > 0 || (moriond_tau_scale && (is_embedded || !is_data) )   ))
     .set_tau_scale(tau_shift)
+    .set_use_most_isolated(strategy_type == strategy::phys14)
+    .set_use_os_preference(strategy_type == strategy::phys14)
     .set_allowed_tau_modes(allowed_tau_modes));
 
 
@@ -716,15 +718,15 @@ if(strategy_type != strategy::phys14){
     .set_jets_label(jets_label));
  }
 
- if(js["make_sync_ntuple"].asBool() && strategy_type!=strategy::phys14){
-    BuildModule(HTTSync("HTTSync","HTTSequenceSyncfiles/SYNCFILE_" + output_name, channel)
-     .set_is_embedded(is_embedded).set_met_label(met_label).set_ditau_label("ditau"));
- }
+// if(js["make_sync_ntuple"].asBool() && strategy_type!=strategy::phys14){
+//    BuildModule(HTTSync("HTTSync","HTTSequenceSyncfiles/SYNCFILE_" + output_name, channel)
+//     .set_is_embedded(is_embedded).set_met_label(met_label).set_ditau_label("ditau"));
+// }
 
- if(js["make_sync_ntuple"].asBool() && strategy_type==strategy::phys14){
-    BuildModule(HTTSyncTemp("HTTSyncTemp","HTTSequenceSyncfiles/SYNCFILE_" + output_name, channel)
-      .set_is_embedded(is_embedded).set_met_label(met_label).set_ditau_label("ditau").set_jet_label(jets_label));
- }
+// if(js["make_sync_ntuple"].asBool() && strategy_type==strategy::phys14){
+//    BuildModule(HTTSyncTemp("HTTSyncTemp","HTTSequenceSyncfiles/SYNCFILE_" + output_name, channel)
+//      .set_is_embedded(is_embedded).set_met_label(met_label).set_ditau_label("ditau").set_jet_label(jets_label));
+// }
 
  BuildModule(HTTCategories("HTTCategories")
     .set_fs(fs.get())
@@ -740,6 +742,7 @@ if(strategy_type != strategy::phys14){
     .set_sync_output_name("HTTSequenceSyncfilesNEW/SYNCFILE"+output_name)
     .set_mass_shift(mass_shift)
     .set_is_embedded(is_embedded)
+    //Good to avoid accidentally overwriting existing output files when syncing
     .set_write_tree(!js["make_sync_ntuple"].asBool()));
 
 }
@@ -824,6 +827,7 @@ void HTTSequence::BuildETPairs() {
   }
 
 
+if(!((js["make_sync_ntuple"]).asBool())) {
   if (js["baseline"]["lep_iso"].asBool() &&strategy_type==strategy::phys14) {
     BuildModule(SimpleFilter<Electron>("ElectronIsoFilter")
         .set_input_label("sel_electrons").set_min(1)
@@ -832,7 +836,7 @@ void HTTSequence::BuildETPairs() {
           //return PF04IsolationEBElec(e, 0.5, 0.15, 0.1);
         }));
   }
-
+}
 
   BuildTauSelection();
 
@@ -894,7 +898,6 @@ void HTTSequence::BuildMTPairs() {
    muon_iso_max = 0.1;
  }
 
-
   if (js["baseline"]["lep_iso"].asBool()&&special_mode !=25 &&special_mode != 22 &&special_mode != 21 &&strategy_type!=strategy::phys14) {
     BuildModule(SimpleFilter<Muon>("MuonIsoFilter")
         .set_input_label("sel_muons").set_min(1)
@@ -905,6 +908,7 @@ void HTTSequence::BuildMTPairs() {
 
 
 
+if(!((js["make_sync_ntuple"]).asBool())) {
   if (js["baseline"]["lep_iso"].asBool()&&strategy_type==strategy::phys14) {
     BuildModule(SimpleFilter<Muon>("MuonIsoFilter")
         .set_input_label("sel_muons").set_min(1)
@@ -912,7 +916,7 @@ void HTTSequence::BuildMTPairs() {
           return PF03IsolationVal(m, 0.5,0)<0.1;
         }));
   }
-
+}
  
 
 
@@ -1003,7 +1007,7 @@ void HTTSequence::BuildEMPairs() {
         }));
   }
 
-
+if(!((js["make_sync_ntuple"]).asBool())) {
   if (js["baseline"]["lep_iso"].asBool() &&strategy_type==strategy::phys14) {
     BuildModule(SimpleFilter<Electron>("ElectronIsoFilter")
         .set_input_label("sel_electrons").set_min(1)
@@ -1011,6 +1015,7 @@ void HTTSequence::BuildEMPairs() {
             return PF03IsolationVal(e, 0.5)<0.15;
         }));
   }
+}
 
   BuildModule(OverlapFilter<Electron, Muon>("ElecMuonOverlapFilter")
       .set_input_label("sel_electrons")
@@ -1069,7 +1074,7 @@ void HTTSequence::BuildEMPairs() {
   }
 
 
-
+if(!((js["make_sync_ntuple"]).asBool())) {
   if (js["baseline"]["lep_iso"].asBool()&&strategy_type==strategy::phys14) {
     BuildModule(SimpleFilter<Muon>("MuonIsoFilter")
         .set_input_label("sel_muons").set_min(1)
@@ -1077,7 +1082,7 @@ void HTTSequence::BuildEMPairs() {
           return PF03IsolationVal(m, 0.5,0)<0.15;
         }));
   }
-
+}
      
   
   BuildModule(CompositeProducer<Electron, Muon>("EMPairProducer")
@@ -1129,6 +1134,7 @@ void HTTSequence::BuildTauSelection(){
 
       }));
 
+if(!( (js["make_sync_ntuple"]).asBool() && strategy_type==strategy::phys14) ) {
   if (base["lep_iso"].asBool()) {
   if(strategy_type!= strategy::phys14 && strategy_type!=strategy::paper2013){
     BuildModule(SimpleFilter<Tau>("TauIsoFilter")
@@ -1177,7 +1183,7 @@ BuildModule(tauAntiElecFilter);
   BuildModule(tauAntiMuonFilter);
   }
  }
-
+}
 void HTTSequence::BuildDiElecVeto() {
   ic::strategy strategy_type  = String2Strategy(strategy_str);
 

--- a/Analysis/HiggsTauTau/src/HTTSequence.cc
+++ b/Analysis/HiggsTauTau/src/HTTSequence.cc
@@ -747,7 +747,7 @@ if(strategy_type != strategy::phys14){
     .set_kinfit_mode(kinfit_mode)
     .set_bjet_regression(bjet_regr_correction)
     .set_make_sync_ntuple(js["make_sync_ntuple"].asBool())
-    .set_sync_output_name("HTTSequenceSyncfilesNEW/SYNCFILE"+output_name)
+    .set_sync_output_name("HTTSequenceSyncfilesNEW/SYNCFILE_"+output_name)
     .set_mass_shift(mass_shift)
     .set_is_embedded(is_embedded)
     //Good to avoid accidentally overwriting existing output files when syncing

--- a/Analysis/HiggsTauTau/test/HiggsTauTau.cpp
+++ b/Analysis/HiggsTauTau/test/HiggsTauTau.cpp
@@ -1116,7 +1116,6 @@ int main(int argc, char* argv[]){
     .set_jets_label(jets_label)
     .set_kinfit_mode(kinfit_mode)
     .set_bjet_regression(bjet_regr_correction)
-    .set_write_plots(true)
     .set_write_tree(true);
   if (mass_scale_mode == 1) httCategories.set_mass_shift(1.00);
   if (mass_scale_mode == 2) httCategories.set_mass_shift(1.01);


### PR DESCRIPTION
This pull request contains the following:
- HTTCategories and HTTSync are merged into one module.
- For phys14 era when a sync tree is made the isolation, tau lepton rejection and extra lepton vetoes are turned off. We also default to no os/ss preference and most isolated pair for the pair selection for phys14 era.
- The extra lepton vetoes are stored to the event as a pass or fail bool, which is then added to the sync ntuple.

Note that the current solution to the extra lepton vetoes is a new module HTTFilter which applies the usual filter of vetoed events when not making a sync tuple and saves the bool quantity when making the sync tuple. It would actually be fairly easy to just modify SimpleFilter to do this (with the modifications defaulted off to not break anything of course).  

There are still more proposed branches to add to the sync ntuple but this is a decent start and a good time to pull request. 