### PR TITLE
adding ability to save met uncertainties to met producer

### DIFF
--- a/interface/LinkDef.h
+++ b/interface/LinkDef.h
@@ -12,6 +12,9 @@
 #pragma link C++ class std::pair<std::string, bool>+;
 #pragma link C++ class std::pair<unsigned long, float>+;
 
+#pragma link C++ class std::pair<std::string,ic::Candidate>+;
+#pragma link C++ class std::vector<std::pair<std::string,ic::Candidate> >+;
+
 #pragma link C++ class ic::Candidate+;
 #pragma link C++ class std::vector<ic::Candidate>+;
 

--- a/interface/Met.hh
+++ b/interface/Met.hh
@@ -64,7 +64,7 @@ class Met : public Candidate {
   /**@}*/
 
   /// @copybrief shiftedmets()
-  inline void set_shiftedmets(std::vector<std::pair<std::string,Candidate> > const& shiftedmets) { shiftedmets_ = shiftedmets; }
+  inline void set_shiftedmets(std::vector<std::pair<std::string,ic::Candidate> > const& shiftedmets) { shiftedmets_ = shiftedmets; }
   /**@}*/
 
  private:
@@ -74,11 +74,11 @@ class Met : public Candidate {
   double xy_sig_;
   double yx_sig_;
   double yy_sig_;
-  std::vector<std::pair<std::string,Candidate> > shiftedmets_;
+  std::vector<std::pair<std::string,ic::Candidate> > shiftedmets_;
 
  #ifndef SKIP_CINT_DICT
  public:
-  ClassDef(Met, 3);
+  ClassDef(Met, 4);
  #endif
 };
 

--- a/interface/Met.hh
+++ b/interface/Met.hh
@@ -1,6 +1,7 @@
 #ifndef ICHiggsTauTau_Met_hh
 #define ICHiggsTauTau_Met_hh
 #include <vector>
+#include <utility>
 #include "UserCode/ICHiggsTauTau/interface/Candidate.hh"
 #include "Rtypes.h"
 
@@ -37,6 +38,10 @@ class Met : public Candidate {
   inline double yy_sig() const { return yy_sig_; }
   /**@}*/
 
+/// The vector of shifted mets
+  inline std::vector<std::pair<std::string,Candidate> > shiftedmets() const { return shiftedmets_; }
+  /**@}*/
+
   /// @name Setters
   /**@{*/
   /// @copybrief sum_et()
@@ -58,6 +63,10 @@ class Met : public Candidate {
   inline void set_yy_sig(double const& yy_sig) { yy_sig_ = yy_sig; }
   /**@}*/
 
+  /// @copybrief shiftedmets()
+  inline void set_shiftedmets(std::vector<std::pair<std::string,Candidate> > const& shiftedmets) { shiftedmets_ = shiftedmets; }
+  /**@}*/
+
  private:
   double sum_et_;
   double et_sig_;
@@ -65,10 +74,11 @@ class Met : public Candidate {
   double xy_sig_;
   double yx_sig_;
   double yy_sig_;
+  std::vector<std::pair<std::string,Candidate> > shiftedmets_;
 
  #ifndef SKIP_CINT_DICT
  public:
-  ClassDef(Met, 2);
+  ClassDef(Met, 3);
  #endif
 };
 

--- a/interface/Met.hh
+++ b/interface/Met.hh
@@ -39,7 +39,7 @@ class Met : public Candidate {
   /**@}*/
 
 /// The vector of shifted mets
-  inline std::vector<std::pair<std::string,Candidate> > shiftedmets() const { return shiftedmets_; }
+  inline std::vector<std::pair<std::string,ic::Candidate> > shiftedmets() const { return shiftedmets_; }
   /**@}*/
 
   /// @name Setters

--- a/plugins/ICMetProducer.hh
+++ b/plugins/ICMetProducer.hh
@@ -17,7 +17,7 @@
 #include "UserCode/ICHiggsTauTau/interface/Met.hh"
 #include "UserCode/ICHiggsTauTau/interface/StaticTree.hh"
 #include "UserCode/ICHiggsTauTau/plugins/PrintConfigTools.h"
-
+#include "FWCore/Utilities/interface/Exception.h"
 
 /**
  * @brief See documentation [here](\ref objs-met)
@@ -207,8 +207,7 @@ void ICMetProducer<reco::MET>::constructSpecific(
       dest.set_sum_et(src.sumEt());
     }
     if(do_metuncertainties_){
-      std::cout<<"metuncertainties not supported for reco::met"<<std::endl;
-      throw;
+      throw cms::Exception("OptionNotSupported")<<"metuncertainties not supported for reco::met\n";
 	}
   }
 
@@ -245,8 +244,7 @@ void ICMetProducer<pat::MET>::constructSpecific(
 	    else if(metuncertainties_[iunc]=="NoShift")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::NoShift);
 	    else if(metuncertainties_[iunc]=="METUncertaintySize")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::METUncertaintySize);
 	    else{
-	      std::cout<<metuncertainties_[iunc]<<" is not a recognised uncertainty!"<<std::endl;
-	      throw;
+	      throw cms::Exception("UncertaintyNotRecognised")<<metuncertainties_[iunc]<<" is not a recognised uncertainty!\n";
 	    }
 	    ic::Candidate thismet;
 	    thismet.set_vector(shiftedvector);

--- a/plugins/ICMetProducer.hh
+++ b/plugins/ICMetProducer.hh
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include "Math/Vector4D.h"
+#include "Math/Vector4Dfwd.h"
 #include "boost/functional/hash.hpp"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -59,6 +61,9 @@ class ICMetProducer : public edm::EDProducer {
   SigTags metsig_;
   SigTagsMethod2 metsig_method2_;
   bool get_raw_from_pat_;
+
+  bool do_metuncertainties_;
+  std::vector<std::string> metuncertainties_;
 };
 
 template <class T>
@@ -83,7 +88,9 @@ ICMetProducer<T>::ICMetProducer(const edm::ParameterSet& config)
       do_external_metsig_(config.getParameter<bool>("includeExternalMetsig")),
       do_external_metsig_method2_(config.getParameter<bool>("includeExternalMetsigMethod2")),
       metsig_(config.getParameterSet("metsig")),
-      metsig_method2_(config.getParameterSet("metsig_method2")) {
+      metsig_method2_(config.getParameterSet("metsig_method2")),
+      do_metuncertainties_(config.getParameter<bool>("includeMetUncertainties")),
+      metuncertainties_(config.getParameter<std::vector<std::string> >("metuncertainties")) {
   met_ = new std::vector<ic::Met>();
   PrintHeaderWithProduces(config, input_, branch_);
   PrintOptional(1, do_custom_id_, "includeCustomID");
@@ -99,7 +106,9 @@ ICMetProducer<pat::MET>::ICMetProducer(const edm::ParameterSet& config)
       do_external_metsig_method2_(config.getParameter<bool>("includeExternalMetsigMethod2")),
       metsig_(config.getParameterSet("metsig")),
       metsig_method2_(config.getParameterSet("metsig_method2")),
-      get_raw_from_pat_(config.getParameter<bool>("getUncorrectedMet")){
+      get_raw_from_pat_(config.getParameter<bool>("getUncorrectedMet")),
+      do_metuncertainties_(config.getParameter<bool>("includeMetUncertainties")),
+      metuncertainties_(config.getParameter<std::vector<std::string> >("metuncertainties")) {
   met_ = new std::vector<ic::Met>();
   PrintHeaderWithProduces(config, input_, branch_);
   PrintOptional(1, do_custom_id_, "includeCustomID");
@@ -196,8 +205,12 @@ void ICMetProducer<reco::MET>::constructSpecific(
       dest.set_phi(src.phi());
       dest.set_energy(src.energy());
       dest.set_sum_et(src.sumEt());
-     }
-   }
+    }
+    if(do_metuncertainties_){
+      std::cout<<"metuncertainties not supported for reco::met"<<std::endl;
+      throw;
+	}
+  }
 
 template <>
 void ICMetProducer<pat::MET>::constructSpecific(
@@ -212,6 +225,38 @@ void ICMetProducer<pat::MET>::constructSpecific(
         dest.set_phi(src.phi());
         dest.set_energy(src.energy());
         dest.set_sum_et(src.sumEt());
+#if CMSSW_MAJOR_VERSION >=7 && CMSSW_MINOR_VERSION >=4
+	if(do_metuncertainties_){
+	  std::vector<std::pair<std::string,ic::Candidate> > metuncs;
+	  for(unsigned iunc=0;iunc<metuncertainties_.size();iunc++){
+	    ROOT::Math::PtEtaPhiEVector shiftedvector;
+	    if(metuncertainties_[iunc]=="JetEnUp")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::JetEnUp);
+	    else if(metuncertainties_[iunc]=="JetEnDown")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::JetEnDown);
+	    else if(metuncertainties_[iunc]=="JetResUp")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::JetResUp);
+	    else if(metuncertainties_[iunc]=="JetResDown")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::JetResDown);
+	    else if(metuncertainties_[iunc]=="MuonEnUp")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::MuonEnUp);
+	    else if(metuncertainties_[iunc]=="MuonEnDown")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::MuonEnDown);
+	    else if(metuncertainties_[iunc]=="ElectronEnUp")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::ElectronEnUp);
+	    else if(metuncertainties_[iunc]=="ElectronEnDown")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::ElectronEnDown);
+	    else if(metuncertainties_[iunc]=="TauEnUp")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::TauEnUp);
+	    else if(metuncertainties_[iunc]=="TauEnDown")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::TauEnDown);
+	    else if(metuncertainties_[iunc]=="UnclusteredEnUp")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::UnclusteredEnUp);
+	    else if(metuncertainties_[iunc]=="UnclusteredEnDown")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::UnclusteredEnDown);
+	    else if(metuncertainties_[iunc]=="NoShift")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::NoShift);
+	    else if(metuncertainties_[iunc]=="METUncertaintySize")shiftedvector=src.shiftedP4(pat::MET::METUncertainty::METUncertaintySize);
+	    else{
+	      std::cout<<metuncertainties_[iunc]<<" is not a recognised uncertainty!"<<std::endl;
+	      throw;
+	    }
+	    ic::Candidate thismet;
+	    thismet.set_vector(shiftedvector);
+	    std::pair<std::string,ic::Candidate> thispair(metuncertainties_[iunc],thismet);
+	    metuncs.push_back(thispair);
+	  }
+	  dest.set_shiftedmets(metuncs);
+
+	}
+#endif
       } else {
 #if CMSSW_MAJOR_VERSION >=7 && CMSSW_MINOR_VERSION >=4
         dest.set_pt(src.uncorrectedPt());

--- a/python/default_producers_cfi.py
+++ b/python/default_producers_cfi.py
@@ -178,7 +178,11 @@ icMetProducer = cms.EDProducer('ICPFMetProducer',
   metsig_method2 = cms.PSet(
     metsig      = cms.InputTag("METSignificance","METSignificance"),
     metsigcov = cms.InputTag("METSignificance","METCovariance")
-    )
+    ),
+  includeMetUncertainties = cms.bool(False),
+  metuncertainties = cms.vstring(
+    'JetEnUp','JetEnDown','JetResUp','JetResDown','MuonEnUp','MuonEnDown','ElectronEnUp','ElectronEnDown','TauEnUp','TauEnDown','UnclusteredEnUp','UnclusteredEnDown'
+  )
   
 )
 
@@ -200,9 +204,11 @@ icMetFromPatProducer = cms.EDProducer('ICPFMetFromPatProducer',
   metsig_method2 = cms.PSet(
     metsig      = cms.InputTag("METSignificance","METSignificance"),
     metsigcov = cms.InputTag("METSignificance","METCovariance")
-    )
-
-  
+    ),
+  includeMetUncertainties = cms.bool(False),
+  metuncertainties = cms.vstring(
+    'JetEnUp','JetEnDown','JetResUp','JetResDown','MuonEnUp','MuonEnDown','ElectronEnUp','ElectronEnDown','TauEnUp','TauEnDown','UnclusteredEnUp','UnclusteredEnDown'
+  )
 )
 
 ## [Met]

--- a/test/higgsinv_7_4_6_miniAODcfg.py
+++ b/test/higgsinv_7_4_6_miniAODcfg.py
@@ -64,7 +64,7 @@ process.TFileService = cms.Service("TFileService",
 # Message Logging, summary, and number of events                                                                                                          
 ################################################################                                                                                          
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(10000)
+  input = cms.untracked.int32(10)
 )
 
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
@@ -759,12 +759,13 @@ process.load("RecoMET/METProducers.METSignificanceParams_cfi")
 
 
 #get type 1 met straight from miniAOD !!update to take in output of met significance calculator
-process.ictype1PfMetProducer = producers.icMetProducer.clone(
+process.ictype1PfMetProducer = producers.icMetFromPatProducer.clone(
                                                     input = cms.InputTag("slimmedMETs"),
                                                     branch = cms.string("pfMetType1Collection"),
                                                     includeCustomID = cms.bool(False),
                                                     inputCustomID = cms.InputTag(""),
-                                                    includeExternalMetsigMethod2 = cms.bool(True)
+                                                    includeExternalMetsigMethod2 = cms.bool(True),
+                                                    includeMetUncertainties = cms.bool(True)
                                                     )
 
 # process.ictype1PfMetProducermetsigoutofbox = producers.icMetProducer.clone(
@@ -821,6 +822,7 @@ process.icMetSequence = cms.Sequence(
 
 #!!MET UNCERTAINTIES
 #!!MET FILTERS
+
 
 ################################################################                                                                                            
 #!! Simulation only: GenParticles, GenJets, PileupInfo                                                                                                        


### PR DESCRIPTION
Default behaviour should be the same as previously, I've added the option to save met uncertainties from slimmedmets as a std::vector<std::pair<std::string,ic::Candidate> > with the entries being the name of the uncertainty and the shifted met vector.