### PR TITLE
adding status flags to genparticles

### DIFF
--- a/Analysis/HiggsNuNu/scripts/DefaultLightTreeConfig_sashadata.cfg
+++ b/Analysis/HiggsNuNu/scripts/DefaultLightTreeConfig_sashadata.cfg
@@ -31,3 +31,5 @@ filelist=./filelists/Oct21/short/Oct21_METembedded_MET-2012A-13Jul2012-v1.dat
 input_prefix=root://xrootd.grid.hep.ph.ic.ac.uk//store/user/amagnan/Oct21/METembedded/
 donoskim=true
 #turnoffpuid=true
+dotkiso=true
+do_selmuonoverlapveto=true

--- a/interface/GenParticle.hh
+++ b/interface/GenParticle.hh
@@ -5,10 +5,31 @@
 #include "Math/Point3Dfwd.h"
 #include "UserCode/ICHiggsTauTau/interface/Candidate.hh"
 #include "Rtypes.h"
-#include "DataFormats/HepMCCandidate/interface/GenStatusFlags.h"
 
 
 namespace ic {
+
+/**
+ * @brief Stores the order of the gen status flags stored inside the ic::GenParticle
+ */
+enum GenStatusBits {
+  IsPrompt = 0,
+  IsDecayedLeptonHadron,
+  IsTauDecayProduct,
+  IsPromptTauDecayProduct,
+  IsDirectTauDecayProduct,
+  IsDirectPromptTauDecayProduct,
+  IsDirectHadronDecayProduct,
+  IsHardProcess,
+  FromHardProcess,
+  IsHardProcessTauDecayProduct,
+  IsDirectHardProcessTauDecayProduct,
+  FromHardProcessBeforeFSR,
+  IsFirstCopy,
+  IsLastCopy,
+  IsLastCopyBeforeFSR
+};
+
 
 /**
  * @brief Stores the basic properties of generator-level particles as well as
@@ -23,7 +44,6 @@ class GenParticle : public Candidate {
   GenParticle();
   virtual ~GenParticle();
   virtual void Print() const;
-
 
   /// @name Properties
   /**@{*/
@@ -46,7 +66,7 @@ class GenParticle : public Candidate {
   inline std::vector<int> const& daughters() const { return daughters_; }
 
   /// A genstatusflags object to give information about the production of the particle
-  inline reco::GenStatusFlags const& statusFlags() const { return statusFlags_; }
+  inline std::vector<bool> const& statusFlags() const { return statusFlags_; }
   /**@}*/
 
   /// @name Setters
@@ -71,7 +91,7 @@ class GenParticle : public Candidate {
   }
 
   /// @copybrief statusFlags()
-  inline void set_statusFlags(reco::GenStatusFlags const& statusFlags) {
+  inline void set_statusFlags(std::vector<bool> const& statusFlags) {
     statusFlags_ = statusFlags;
   }
   /**@}*/
@@ -82,12 +102,11 @@ class GenParticle : public Candidate {
   int status_;
   std::vector<int> mothers_;
   std::vector<int> daughters_;
-  reco::GenStatusFlags statusFlags_;
-
+  std::vector<bool> statusFlags_;
 
  #ifndef SKIP_CINT_DICT
  public:
-  ClassDef(GenParticle, 3);
+  ClassDef(GenParticle, 4);
  #endif
 };
 

--- a/interface/GenParticle.hh
+++ b/interface/GenParticle.hh
@@ -5,6 +5,8 @@
 #include "Math/Point3Dfwd.h"
 #include "UserCode/ICHiggsTauTau/interface/Candidate.hh"
 #include "Rtypes.h"
+#include "DataFormats/HepMCCandidate/interface/GenStatusFlags.h"
+
 
 namespace ic {
 
@@ -21,6 +23,7 @@ class GenParticle : public Candidate {
   GenParticle();
   virtual ~GenParticle();
   virtual void Print() const;
+
 
   /// @name Properties
   /**@{*/
@@ -41,6 +44,9 @@ class GenParticle : public Candidate {
   /// A vector of ic::GenParticle::index() values that identify the daughter
   /// particles
   inline std::vector<int> const& daughters() const { return daughters_; }
+
+  /// A genstatusflags object to give information about the production of the particle
+  inline reco::GenStatusFlags const& statusFlags() const { return statusFlags_; }
   /**@}*/
 
   /// @name Setters
@@ -63,6 +69,11 @@ class GenParticle : public Candidate {
   inline void set_daughters(std::vector<int> const& daughters) {
     daughters_ = daughters;
   }
+
+  /// @copybrief statusFlags()
+  inline void set_statusFlags(reco::GenStatusFlags const& statusFlags) {
+    statusFlags_ = statusFlags;
+  }
   /**@}*/
 
  private:
@@ -71,10 +82,12 @@ class GenParticle : public Candidate {
   int status_;
   std::vector<int> mothers_;
   std::vector<int> daughters_;
+  reco::GenStatusFlags statusFlags_;
+
 
  #ifndef SKIP_CINT_DICT
  public:
-  ClassDef(GenParticle, 2);
+  ClassDef(GenParticle, 3);
  #endif
 };
 

--- a/plugins/ICGenParticleProducer.cc
+++ b/plugins/ICGenParticleProducer.cc
@@ -17,12 +17,14 @@ ICGenParticleProducer::ICGenParticleProducer(const edm::ParameterSet& config)
     : input_(config.getParameter<edm::InputTag>("input")),
       branch_(config.getParameter<std::string>("branch")),
       store_mothers_(config.getParameter<bool>("includeMothers")),
-      store_daughters_(config.getParameter<bool>("includeDaughters")) {
+      store_daughters_(config.getParameter<bool>("includeDaughters")),
+      store_statusFlags_(config.getParameter<bool>("includeStatusFlags")){
   particles_ = new std::vector<ic::GenParticle>();
 
   PrintHeaderWithProduces(config, input_, branch_);
   PrintOptional(1, store_mothers_, "includeMothers");
   PrintOptional(1, store_daughters_, "includeDaughters");
+  PrintOptional(1, store_statusFlags_, "includeStatusFlags");
 }
 
 ICGenParticleProducer::~ICGenParticleProducer() { delete particles_; }
@@ -48,6 +50,9 @@ void ICGenParticleProducer::produce(edm::Event& event,
     dest.set_index(static_cast<int>((parts_handle->refAt(i).key())));
     dest.set_pdgid(src.pdgId());
     dest.set_status(src.status());
+    if (store_statusFlags_){
+      dest.set_statusFlags(src.statusFlags());
+    }
     if (store_mothers_) {
       std::vector<int> mothers(src.motherRefVector().size(), 0);
       for (unsigned j = 0; j < src.motherRefVector().size(); ++j) {

--- a/plugins/ICGenParticleProducer.hh
+++ b/plugins/ICGenParticleProducer.hh
@@ -33,6 +33,7 @@ class ICGenParticleProducer : public edm::EDProducer {
 
   bool store_mothers_;
   bool store_daughters_;
+  bool store_statusFlags_;
 };
 
 #endif

--- a/python/default_producers_cfi.py
+++ b/python/default_producers_cfi.py
@@ -434,7 +434,8 @@ icGenParticleProducer = cms.EDProducer('ICGenParticleProducer',
   branch  = cms.string("genParticles"),
   input   = cms.InputTag("genParticles"),
   includeMothers = cms.bool(True),
-  includeDaughters = cms.bool(True)
+  includeDaughters = cms.bool(True),
+  includeStatusFlags = cms.bool(False)
 )
 ## [GenParticle]
 

--- a/test/higgsinv_7_4_6_miniAODcfg.py
+++ b/test/higgsinv_7_4_6_miniAODcfg.py
@@ -30,8 +30,8 @@ opts.register('isData', 0, parser.VarParsing.multiplicity.singleton,
     parser.VarParsing.varType.int, "Process as data?")
 opts.register('release', '74XMINIAOD', parser.VarParsing.multiplicity.singleton,
     parser.VarParsing.varType.string, "Release label")
-opts.register('isNLO', 0, parser.VarParsing.multiplicity.singleton,
-    parser.VarParsing.varType.int, "Store sign of weight?")
+opts.register('isNLO', False, parser.VarParsing.multiplicity.singleton,
+    parser.VarParsing.varType.bool, "Store sign of weight?")
 
 opts.parseArguments()
 infile      = opts.file
@@ -67,7 +67,7 @@ process.TFileService = cms.Service("TFileService",
 # Message Logging, summary, and number of events                                                                                                          
 ################################################################                                                                                          
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(1000)
+  input = cms.untracked.int32(300)
 )
 
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
@@ -861,14 +861,16 @@ process.prunedGenParticlesTaus = cms.EDProducer("ICGenParticlePruner",
 process.icGenParticleProducer = producers.icGenParticleProducer.clone(
   input   = cms.InputTag("icPrunedGenParticles"),
   includeMothers = cms.bool(True),
-  includeDaughters = cms.bool(True)
+  includeDaughters = cms.bool(True),
+  includeStatusFlags = cms.bool(True)
 )
 
 process.icGenParticleTauProducer = producers.icGenParticleProducer.clone(
   input   = cms.InputTag("prunedGenParticlesTaus"),
   branch = cms.string("genParticlesTaus"),
   includeMothers = cms.bool(True),
-  includeDaughters = cms.bool(True)
+  includeDaughters = cms.bool(True),
+  includeStatusFlags = cms.bool(True)
 )
 
 
@@ -1040,7 +1042,7 @@ process.HBHENoiseFilterResultProducer.minZeros = cms.int32(99999)
 
 
 process.icEventInfoProducer = producers.icEventInfoProducer.clone(
-  isNlo               =isNLO,
+  isNlo               = isNLO,
   includeJetRho       = cms.bool(True),
   inputJetRho         = cms.InputTag("fixedGridRhoFastjetAll"),
   includeLeptonRho    = cms.bool(False),

--- a/test/higgsinvcrab/crab_run2background.py
+++ b/test/higgsinvcrab/crab_run2background.py
@@ -1,5 +1,5 @@
 from WMCore.Configuration import Configuration
-prod='Jul27'
+prod='Aug14'
 config = Configuration()
 config.section_('General')
 config.section_('Data')
@@ -100,8 +100,8 @@ if __name__ == '__main__':
     tasks.append(('ZZ-pythia8-50ns','/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM')) 
     tasks.append(('WW2L2Nu-powheg-50ns','/WWTo2L2Nu_13TeV-powheg/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
     tasks.append(('WW4Q-powheg-50ns','/WWTo4Q_13TeV-powheg/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v3/MINIAODSIM'))
-#    tasks.append(('WWLNuQQ-powheg-50ns','/WWToLNuQQ_13TeV-powheg/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
-#    tasks.append(('WZLNuQQ-mg-50ns','/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
+    tasks.append(('WWLNuQQ-powheg-50ns','/WWToLNuQQ_13TeV-powheg/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
+    tasks.append(('WZLNuQQ-mg-50ns','/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
     tasks.append(('ZZ4L-powheg-50ns','/ZZTo4L_13TeV_powheg_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
 
     #QCD
@@ -111,14 +111,14 @@ if __name__ == '__main__':
     tasks.append(('SingleT-tW-powheg-inc-50ns','/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
     tasks.append(('SingleT-t-powheg-lep-50ns','/ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
     tasks.append(('SingleTBar-t-powheg-lep-50ns','/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
-#    tasks.append(('SingleT-s-amcatnlo-lep-50ns','/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
+    tasks.append(('SingleT-s-amcatnlo-lep-50ns','/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
     tasks.append(('TTJets-mg-50ns','/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
     tasks.append(('TT-powheg-50ns','/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM'))
     
     #V+jets
     tasks.append(('WJetsToLNu-50ns','/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
-    tasks.append(('DYJetsToLL-50ns','/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v3/MINIAODSIM'))
-#    tasks.append(('DYJetsToLL-M_10to50-50ns','/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
+    tasks.append(('DYJetsToLL-50ns','/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9-v3/MINIAODSIM'))
+    tasks.append(('DYJetsToLL-M_10to50-50ns','/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM'))
 
 
 

--- a/test/higgsinvcrab/crab_run2data.py
+++ b/test/higgsinvcrab/crab_run2data.py
@@ -1,5 +1,5 @@
 from WMCore.Configuration import Configuration
-prod ='Jul27'
+prod ='Aug14'
 config = Configuration()
 config.section_('General')
 config.section_('Data')


### PR DESCRIPTION
Gen status flags added to gen particle and producer using reco::GenStatusFlags object that's in miniAOD. By default these are not stored. I'm happy to leave this open until Adinda gets back from holiday to take a look.