### PR TITLE
Adding complex filter module

### DIFF
--- a/Analysis/HiggsNuNu/test/LightTreeMakerFromMiniAOD.cpp
+++ b/Analysis/HiggsNuNu/test/LightTreeMakerFromMiniAOD.cpp
@@ -17,6 +17,7 @@
 
 #include "UserCode/ICHiggsTauTau/Analysis/Modules/interface/CopyCollection.h"
 #include "UserCode/ICHiggsTauTau/Analysis/Modules/interface/SimpleFilter.h"
+#include "UserCode/ICHiggsTauTau/Analysis/Modules/interface/ComplexFilter.h"
 #include "UserCode/ICHiggsTauTau/Analysis/Modules/interface/OverlapFilter.h"
 #include "UserCode/ICHiggsTauTau/Analysis/Modules/interface/IDOverlapFilter.h"
 #include "UserCode/ICHiggsTauTau/Analysis/Modules/interface/CompositeProducer.h"
@@ -240,6 +241,7 @@ int main(int argc, char* argv[]){
   //double veto_muon_dz, veto_muon_dxy;
   double elec_pt, elec_eta, muon_pt, muon_eta;
   double veto_elec_pt, veto_elec_eta, veto_muon_pt, veto_muon_eta;
+  double loose_photon_pt, loose_photon_eta, medium_photon_pt, medium_photon_eta, tight_photon_pt, tight_photon_eta;
   
   elec_dz = 0.1;
   elec_dxy = 0.02;
@@ -259,6 +261,13 @@ int main(int argc, char* argv[]){
   veto_elec_eta = 2.4;
   veto_muon_pt = 10.0;
   veto_muon_eta = 2.1;
+
+  loose_photon_pt = 15;
+  loose_photon_eta = 2.5;
+  medium_photon_pt = 15;
+  medium_photon_eta = 2.5;
+  tight_photon_pt = 15;
+  tight_photon_eta = 2.5;
 
   std::cout << "----------PARAMETERS----------" << std::endl;
   std::cout << boost::format("%-15s %-10s\n") % "elec_pt:" % elec_pt;
@@ -394,6 +403,47 @@ int main(int argc, char* argv[]){
     .set_input_label("vertices")
     .set_predicate(bind(DummyFunction<Vertex>, _1))
     .set_min(1)
+    .set_max(999);
+
+  // ------------------------------------------------------------------------------------
+  // Photon Modules
+  // ------------------------------------------------------------------------------------
+  //loose photons
+  CopyCollection<Photon>  loosePhotonCopyCollection("CopyToLoosePhotons","photons","loosePhotons");
+  
+  SimpleFilter<Photon> loosePhotonPtEtaFilter = SimpleFilter<Photon>
+    ("LoosePhotonPtEtaFilter")
+    .set_input_label("loosePhotons").set_predicate(bind(MinPtMaxEta, _1, loose_photon_pt, loose_photon_eta))
+    .set_min(0)
+    .set_max(999);
+
+  ComplexFilter<Photon,EventInfo,double> loosePhotonIDFilter = ComplexFilter<Photon,EventInfo,double>
+    ("LoosePhotonIDFilter")
+    .set_primary_input_label("loosePhotons").set_predicate(bind(LoosePhotonIDSpring15, _1,_2))
+    .set_secondary_input_label("eventinfo").set_secondary_predicate(bind(&EventInfo::jet_rho,_1))
+    .set_min(0)
+    .set_max(999);
+  
+  //medium photons
+  CopyCollection<Photon>  mediumPhotonCopyCollection("CopyToMediumPhotons","photons","mediumPhotons");
+  
+  SimpleFilter<Photon> mediumPhotonFilter = SimpleFilter<Photon>
+    ("MediumPhotonPtEtaFilter")
+    .set_input_label("mediumPhotons").set_predicate(bind(MinPtMaxEta, _1, medium_photon_pt, medium_photon_eta) //&&
+						    //bind(MediumPhotonIDSpring15, _1)
+						   )
+    .set_min(0)
+    .set_max(999);
+
+  //tight photons
+  CopyCollection<Photon>  tightPhotonCopyCollection("CopyToTightPhotons","photons","tightPhotons");
+  
+  SimpleFilter<Photon> tightPhotonFilter = SimpleFilter<Photon>
+    ("TightPhotonPtEtaFilter")
+    .set_input_label("tightPhotons").set_predicate(bind(MinPtMaxEta, _1, tight_photon_pt, tight_photon_eta) //&&
+						   //bind(TightPhotonIDSpring15, _1)
+						   )
+    .set_min(0)
     .set_max(999);
 
   // ------------------------------------------------------------------------------------

--- a/Analysis/Modules/interface/ComplexFilter.h
+++ b/Analysis/Modules/interface/ComplexFilter.h
@@ -56,7 +56,7 @@ int ComplexFilter<T,U,V>::PreAnalysis() {
 template <class T,class U,class V>
 int ComplexFilter<T,U,V>::Execute(TreeEvent *event) {
   std::vector<T *> & vec = event->GetPtrVec<T>(primary_input_label_);
-  U const* secondary = event->GetPtr<EventInfo>(secondary_input_label_);
+  U const* secondary = event->GetPtr<U>(secondary_input_label_);
 
   const V extrainfo=secondary_predicate_(secondary);
   

--- a/Analysis/Modules/interface/ComplexFilter.h
+++ b/Analysis/Modules/interface/ComplexFilter.h
@@ -1,0 +1,110 @@
+ #ifndef ICHiggsTauTau_Module_ComplexFilter_h
+#define ICHiggsTauTau_Module_ComplexFilter_h
+
+#include "UserCode/ICHiggsTauTau/Analysis/Core/interface/TreeEvent.h"
+#include "UserCode/ICHiggsTauTau/Analysis/Core/interface/ModuleBase.h"
+#include "UserCode/ICHiggsTauTau/Analysis/Utilities/interface/FnPredicates.h"
+#include "boost/function.hpp"
+
+#include <string>
+
+namespace ic {
+
+template <class T, class U, class V>
+class ComplexFilter : public ModuleBase {
+ private:
+    boost::function<bool (T const*,V const&)> predicate_;
+    boost::function<V (U const*)> secondary_predicate_;
+    std::string primary_input_label_;
+    std::string secondary_input_label_;
+    unsigned min_;
+    unsigned max_;
+
+ public:
+    virtual ComplexFilter<T,U,V> & set_predicate(boost::function<bool (T const*,const V)> const& predicate){predicate_=predicate; return *this; }
+    virtual ComplexFilter<T,U,V> & set_secondary_predicate(boost::function<V (U const*)> const& secondary_predicate){secondary_predicate_=secondary_predicate; return *this; }
+    virtual ComplexFilter<T,U,V> & set_primary_input_label(std::string const& primary_input_label){primary_input_label_=primary_input_label;return *this; }
+    virtual ComplexFilter<T,U,V> & set_secondary_input_label(std::string const& secondary_input_label){secondary_input_label_=secondary_input_label;return *this; }
+    virtual ComplexFilter<T,U,V> & set_min(unsigned const& min){min_=min; return *this; }
+    virtual ComplexFilter<T,U,V> & set_max(unsigned const& max){max_=max; return *this; }
+    
+  ComplexFilter(std::string const& name);
+  virtual ~ComplexFilter();
+
+  virtual int PreAnalysis();
+  virtual int Execute(TreeEvent *event);
+  virtual int PostAnalysis();
+  virtual void PrintInfo();
+};
+
+template <class T, class U, class V>
+ComplexFilter<T,U,V>::ComplexFilter(std::string const& name) : ModuleBase(name) {
+  min_ = 0;
+  max_ = 9999;
+}
+
+template <class T,class U,class V>
+ComplexFilter<T,U,V>::~ComplexFilter() {
+  ;
+}
+
+template <class T,class U,class V>
+int ComplexFilter<T,U,V>::PreAnalysis() {
+  return 0;
+}
+
+template <class T,class U,class V>
+int ComplexFilter<T,U,V>::Execute(TreeEvent *event) {
+  std::vector<T *> & vec = event->GetPtrVec<T>(primary_input_label_);
+  U const* secondary = event->GetPtr<EventInfo>(secondary_input_label_);
+
+  const V extrainfo=secondary_predicate_(secondary);
+  
+  boost::function<bool (T const*)> final_predicate = boost::bind(predicate_,_1,extrainfo);
+  ic::erase_if(vec,!boost::bind(final_predicate,_1));
+  if (vec.size() >= min_ && vec.size() <= max_) {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+
+// template <>
+// int ComplexFilter<CompositeCandidate>::Execute(TreeEvent *event) {
+//   std::vector<CompositeCandidate> & vec = event->Get<std::vector<CompositeCandidate> >(input_label_);
+//   std::vector<CompositeCandidate *> tmp;
+//   tmp.resize(vec.size());
+//   for (unsigned i = 0; i < vec.size(); ++i) {
+//     tmp[i] = &(vec[i]);
+//   }
+//   ic::erase_if(tmp,!boost::bind(predicate_,_1));
+//   std::vector<CompositeCandidate> copy;
+//   copy.resize(tmp.size());
+//   for (unsigned i = 0; i < tmp.size(); ++i) {
+//     copy[i] = *(tmp[i]);
+//   }
+//   event->ForceAdd(input_label_, copy); 
+//   if (tmp.size() >= min_ && tmp.size() <= max_) {
+//     return 0;
+//   } else {
+//     return 1;
+//   }
+// }
+
+template <class T,class U,class V>
+int ComplexFilter<T,U,V>::PostAnalysis() {
+  return 0;
+}
+
+template <class T,class U,class V>
+void ComplexFilter<T,U,V>::PrintInfo() {
+  ;
+}
+
+
+
+
+
+}
+
+#endif

--- a/Analysis/Modules/src/ComplexFilter.cc
+++ b/Analysis/Modules/src/ComplexFilter.cc
@@ -1,0 +1,5 @@
+#include "UserCode/ICHiggsTauTau/Analysis/Modules/interface/ComplexFilter.h"
+
+namespace ic {
+
+}


### PR DESCRIPTION
Adding a module which can filter an object collection using information held in a different object, e.g. the event info.

It takes two function predicates one which returns a bool and has two parameters of types A and B and another predicate which returns type B and has one parameter of type C.

The use case implemented in HiggsNuNu is getting the jet_rho (which is a double) from the EventInfo, and using it as an input to the PhotonID functions.