### PR TITLE
Adding ecal/hcal pf cluster iso for electrons

### DIFF
--- a/interface/Electron.hh
+++ b/interface/Electron.hh
@@ -62,6 +62,16 @@ class Electron : public Candidate {
     return dr03_hcal_tower_sum_et_;
   }
 
+  ///ECAL PF cluster isolation
+  inline float ecal_pf_cluster_iso() const {
+    return ecal_pf_cluster_iso_;
+  }
+
+  ///HCAL PF cluster isolation
+  inline float hcal_pf_cluster_iso() const {
+    return hcal_pf_cluster_iso_;
+  }
+
   /// PF isolation, using all charged particles in a cone with
   /// \f$ \Delta R = 0.3 \f$
   inline float dr03_pfiso_charged_all() const {
@@ -201,6 +211,16 @@ class Electron : public Candidate {
   /// @copybrief dr03_hcal_tower_sum_et()
   inline void set_dr03_hcal_tower_sum_et(float const& dr03_hcal_tower_sum_et) {
     dr03_hcal_tower_sum_et_ = dr03_hcal_tower_sum_et;
+  }
+
+  /// @copybrief ecal_pf_cluster_iso()
+  inline void set_ecal_pf_cluster_iso(float const& ecal_pf_cluster_iso) {
+    ecal_pf_cluster_iso_ = ecal_pf_cluster_iso;
+  }
+
+  /// @copybrief hcal_pf_cluster_iso()
+  inline void set_hcal_pf_cluster_iso(float const& hcal_pf_cluster_iso){
+    hcal_pf_cluster_iso_ = hcal_pf_cluster_iso;
   }
 
   /// @copybrief dr03_pfiso_charged_all()
@@ -380,6 +400,10 @@ class Electron : public Candidate {
   float dr03_tk_sum_pt_;
   float dr03_ecal_rechit_sum_et_;
   float dr03_hcal_tower_sum_et_;
+ 
+  //ecal/hcal pf cluster isolation 
+  float ecal_pf_cluster_iso_;
+  float hcal_pf_cluster_iso_;
 
   // PF-based isolation variables
   float dr03_pfiso_charged_all_;
@@ -425,7 +449,7 @@ class Electron : public Candidate {
 
  #ifndef SKIP_CINT_DICT
  public:
-  ClassDef(Electron, 3);
+  ClassDef(Electron, 4);
  #endif
 };
 

--- a/plugins/ICElectronProducer.hh
+++ b/plugins/ICElectronProducer.hh
@@ -52,8 +52,17 @@ class ICElectronProducer : public edm::EDProducer {
     explicit IsoTags(edm::ParameterSet const& pset);
   };
 
+  struct ClusterIsoTags {
+    edm::InputTag ecal;
+    edm::InputTag hcal;
+    explicit ClusterIsoTags(edm::ParameterSet const& pset);
+  };
+
+
+  ClusterIsoTags cluster_iso_;
   IsoTags pf_iso_03_;
   IsoTags pf_iso_04_;
+  bool do_cluster_iso_;
   bool do_pf_iso_03_;
   bool do_pf_iso_04_;
 };

--- a/plugins/ICLeptonIsolation.hh
+++ b/plugins/ICLeptonIsolation.hh
@@ -94,7 +94,11 @@ void ICLeptonIsolation<pat::Electron>::constructSpecific(
       values[i] = src.pfIsolationVariables().sumPUPt;
 //    } else if(input_isolation_type_ == "allcharged_iso"){
  //     values[i] = src.chargedIso();
-    } else values[i] = 0;
+    } else if(input_isolation_type_ == "ecal_pf_cluster_iso"){
+      values[i] = src.ecalPFClusterIso();
+    } else if(input_isolation_type_ == "hcal_pf_cluster_iso"){
+      values[i] = src.hcalPFClusterIso();
+    }  else values[i] = 0;
 #endif
   }
 }

--- a/python/default_producers_cfi.py
+++ b/python/default_producers_cfi.py
@@ -60,7 +60,12 @@ icElectronProducer = cms.EDProducer('ICElectronProducer',
       neutral     = cms.InputTag("elPFIsoValueNeutral04PFIdPFIso"),
       gamma       = cms.InputTag("elPFIsoValueGamma04PFIdPFIso"),
       pu          = cms.InputTag("elPFIsoValuePU04PFIdPFIso")
-    )
+    ),
+   includeClusterIso       = cms.bool(False),
+   clusterIso = cms.PSet(
+     ecal        = cms.InputTag("elEcalPFClusterIso"),
+     hcal        = cms.InputTag("elHcalPFClusterIso")
+   )   
 )
 ## [Electron]
 

--- a/src/Electron.cc
+++ b/src/Electron.cc
@@ -9,6 +9,8 @@ Electron::Electron()
       dr03_tk_sum_pt_(0.),
       dr03_ecal_rechit_sum_et_(0.),
       dr03_hcal_tower_sum_et_(0.),
+      ecal_pf_cluster_iso_(0.),
+      hcal_pf_cluster_iso_(0.),
       dr03_pfiso_charged_all_(0.),
       dr03_pfiso_charged_(0.),
       dr03_pfiso_neutral_(0.),

--- a/test/higgstautau_cfg_74X_Sep15.py
+++ b/test/higgstautau_cfg_74X_Sep15.py
@@ -10,10 +10,11 @@ opts = parser.VarParsing ('analysis')
 #opts.register('file', 'file:/afs/cern.ch/work/a/adewit/private/CMSSW_7_4_4/src/UserCode/ICHiggsTauTau/test/testinput.root', parser.VarParsing.multiplicity.singleton,
 #opts.register('file', 'file:/afs/cern.ch/work/a/adewit/private/CMSSW_7_4_5/src/UserCode/ICHiggsTauTau/test/TauDataTest.root', parser.VarParsing.multiplicity.singleton,
 opts.register('file',
+'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/SUSYGluGluToHToTauTau_M-1000_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/50000/9EF16FCE-E771-E511-AAB0-008CFA1979EC.root',parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/data/Run2015B/SingleElectron/MINIAOD/PromptReco-v1/000/251/163/00000/9C435096-9F26-E511-A1D7-02163E012AB6.root',parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/data/Run2015D/MuonEG/MINIAOD/PromptReco-v3/000/256/630/00000/24F810E0-335F-E511-94F4-02163E011C61.root', parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/00000/0014DC94-DC5C-E511-82FB-7845C4FC39F5.root', parser.VarParsing.multiplicity.singleton,
-'root://xrootd.unl.edu//store/mc/RunIISpring15DR74/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/10000/02D2D410-2A03-E511-8F6C-0025905A60A8.root', parser.VarParsing.multiplicity.singleton,
+#'root://xrootd.unl.edu//store/mc/RunIISpring15DR74/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/10000/02D2D410-2A03-E511-8F6C-0025905A60A8.root', parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/mc/RunIISpring15DR74/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v1/10000/2A3929AE-5303-E511-9EFE-0025905A48C0.root', parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/data/Run2015C/SingleElectron/MINIAOD/PromptReco-v1/000/254/317/00000/C4F3838C-8345-E511-9AA9-02163E011FE4.root', parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/data/Run2015B/SingleElectron/MINIAOD/PromptReco-v1/000/251/164/00000/4633CC68-A326-E511-95D0-02163E0124EA.root', parser.VarParsing.multiplicity.singleton,
@@ -28,7 +29,7 @@ opts.register('globalTag', '74X_mcRun2_asymptotic_v2', parser.VarParsing.multipl
 opts.register('isData', 0, parser.VarParsing.multiplicity.singleton,
     parser.VarParsing.varType.int, "Process as data?")
 #opts.register('release', '7412MINIAOD', parser.VarParsing.multiplicity.singleton,
-opts.register('release', '74X', parser.VarParsing.multiplicity.singleton,
+opts.register('release', '7412MINIAOD', parser.VarParsing.multiplicity.singleton,
     parser.VarParsing.varType.string, "Release label")
 opts.register('isNLO', 0, parser.VarParsing.multiplicity.singleton,
     parser.VarParsing.varType.int, "Is this an NLO sample?")
@@ -526,6 +527,18 @@ if release in ['74XMINIAOD','7412MINIAOD']:
     iso_type = cms.string("pu_iso") 
   )    
 
+  process.elEcalPFClusterIso = cms.EDProducer('ICElectronIsolation',
+    input        = electronLabel,
+    deltaR       = cms.double(0.3), 
+    iso_type     = cms.string("ecal_pf_cluster_iso")
+  )
+
+  process.elHcalPFClusterIso = cms.EDProducer('ICElectronIsolation',
+    input        = electronLabel,
+    deltaR       = cms.double(0.3), 
+    iso_type     = cms.string("hcal_pf_cluster_iso")
+  )
+
 if release in ['74X']:#Need to recalculate this as 04 isolation is stored in pat not reco electrons
   process.elPFIsoValueCharged04PFIdPFIso    = process.elPFIsoValueCharged04PFId.clone()
   process.elPFIsoValueGamma04PFIdPFIso      = process.elPFIsoValueGamma04PFId.clone()
@@ -560,7 +573,9 @@ process.electronPFIsolationValuesSequence +=cms.Sequence(
   process.elPFIsoValueGamma04PFIdPFIso+
   process.elPFIsoValuePU04PFIdPFIso+
   process.elPFIsoValueNeutral04PFIdPFIso+
-  process.elPFIsoValueChargedAll04PFIdPFIso
+  process.elPFIsoValueChargedAll04PFIdPFIso+
+  process.elEcalPFClusterIso+
+  process.elHcalPFClusterIso
 )
 
 
@@ -579,11 +594,14 @@ process.icElectronProducer = producers.icElectronProducer.clone(
      mvaNonTrigSpring15    = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"),
      mvaTrigSpring15       = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15Trig25nsV1Values")
   ),
+  includeClusterIso        = cms.bool(True),
   includePFIso03           = cms.bool(True),
   includePFIso04           = cms.bool(True)
 )
 
 
+if release in ['74X']:
+  process.icElectronProducer.includeClusterIso = cms.bool(False)
 
 process.icElectronSequence += cms.Sequence(
   process.icElectronConversionCalculator+


### PR DESCRIPTION
These are needed for electron triggering mva preselection:
 - Currently only work for miniAOD (will implement for AOD if we decide to switch to triggering mva)
 - Disabled by default so shouldn't disrupt any old configs