### PR TITLE
Fully removing metuncertainties/corrections from reco met producer

### DIFF
--- a/plugins/ICMetProducer.hh
+++ b/plugins/ICMetProducer.hh
@@ -92,9 +92,9 @@ ICMetProducer<T>::ICMetProducer(const edm::ParameterSet& config)
       do_external_metsig_(config.getParameter<bool>("includeExternalMetsig")),
       do_external_metsig_method2_(config.getParameter<bool>("includeExternalMetsigMethod2")),
       metsig_(config.getParameterSet("metsig")),
-      metsig_method2_(config.getParameterSet("metsig_method2")),
-      do_metuncertainties_(config.getParameter<bool>("includeMetUncertainties")),
-      metuncertainties_(config.getParameter<std::vector<std::string> >("metuncertainties")) {
+      metsig_method2_(config.getParameterSet("metsig_method2")){
+      //do_metuncertainties_(config.getParameter<bool>("includeMetUncertainties")),
+      //metuncertainties_(config.getParameter<std::vector<std::string> >("metuncertainties")) {
   met_ = new std::vector<ic::Met>();
   PrintHeaderWithProduces(config, input_, branch_);
   PrintOptional(1, do_custom_id_, "includeCustomID");
@@ -118,6 +118,8 @@ ICMetProducer<pat::MET>::ICMetProducer(const edm::ParameterSet& config)
   met_ = new std::vector<ic::Met>();
   PrintHeaderWithProduces(config, input_, branch_);
   PrintOptional(1, do_custom_id_, "includeCustomID");
+  PrintOptional(1, do_metuncertainties_, "includeMetUncertainties");
+  PrintOptional(1, do_metcorrections_, "includeMetCorrections");
 }
 
 
@@ -210,12 +212,6 @@ void ICMetProducer<reco::MET>::constructSpecific(
       dest.set_energy(src.energy());
       dest.set_sum_et(src.sumEt());
     }
-    if(do_metuncertainties_){
-      throw cms::Exception("OptionNotSupported")<<"metuncertainties not supported for reco::met\n";
-	}
-    if(do_metcorrections_){
-      throw cms::Exception("OptionNotSupported")<<"metcorrections not supported for reco::met\n";
-	}
   }
 
 template <>

--- a/python/default_producers_cfi.py
+++ b/python/default_producers_cfi.py
@@ -185,12 +185,12 @@ icMetProducer = cms.EDProducer('ICPFMetProducer',
     metsig      = cms.InputTag("METSignificance","METSignificance"),
     metsigcov = cms.InputTag("METSignificance","METCovariance")
     ),
-  includeMetCorrections = cms.bool(False),
-  metcorrections = cms.vstring(
-        'Raw','Type1','Type01','TypeXY','Type1XY','Type01XY','Type1Smear','Type01Smear','Type1SmearXY','Type01SmearXY','RawCalo'),
-  includeMetUncertainties = cms.bool(False),
-  metuncertainties = cms.vstring(
-        'JetResUp','JetResDown','JetEnUp','JetEnDown','MuonEnUp','MuonEnDown','ElectronEnUp','ElectronEnDown','TauEnUp','TauEnDown','UnclusteredEnUp','UnclusteredEnDown','PhotonEnUp','PhotonEnDown','NoShift')
+  #includeMetCorrections = cms.bool(False),
+  #metcorrections = cms.vstring(
+  #      'Raw','Type1','Type01','TypeXY','Type1XY','Type01XY','Type1Smear','Type01Smear','Type1SmearXY','Type01SmearXY','RawCalo'),
+  #includeMetUncertainties = cms.bool(False),
+  #metuncertainties = cms.vstring(
+  #      'JetResUp','JetResDown','JetEnUp','JetEnDown','MuonEnUp','MuonEnDown','ElectronEnUp','ElectronEnDown','TauEnUp','TauEnDown','UnclusteredEnUp','UnclusteredEnDown','PhotonEnUp','PhotonEnDown','NoShift')
 )
 
 icMetFromPatProducer = cms.EDProducer('ICPFMetFromPatProducer',

--- a/test/crab_higgstautau_2015D.py
+++ b/test/crab_higgstautau_2015D.py
@@ -2,14 +2,14 @@ from WMCore.Configuration import Configuration
 config = Configuration()
 config.section_('General')
 config.General.transferOutputs = True
-config.General.workArea='Oct15_Data_74X'
+config.General.workArea='Oct30_Data_74X'
 #config.General.requestName = 'May13_MC'
 config.section_('JobType')
 config.JobType.psetName = '/afs/cern.ch/work/a/adewit/private/CMSSW_7_4_12/src/UserCode/ICHiggsTauTau/test/higgstautau_cfg_74X_Sep15.py'
 config.JobType.pluginName = 'Analysis'
 config.JobType.outputFiles = ['EventTree.root']
 #config.JobType.inputFiles = ['Summer15_V5_MC.db']
-config.JobType.pyCfgParams = ['release=7412MINIAOD','isData=1','isNLO=0', 'globalTag=74X_dataRun2_Prompt_v2']
+config.JobType.pyCfgParams = ['release=7412MINIAOD','isData=1','isNLO=0', 'globalTag=74X_dataRun2_Prompt_v4']
 config.section_('Data')
 #config.Data.inputDataset = 'DUMMY'
 #config.Data.unitsPerJob = 30000 
@@ -17,7 +17,7 @@ config.Data.unitsPerJob = 1
 config.Data.splitting = 'FileBased'
 config.Data.publication = False
 config.Data.ignoreLocality=False
-config.Data.outLFNDirBase='/store/user/adewit/Oct15_Data_74X/'
+config.Data.outLFNDirBase='/store/user/adewit/Oct30_Data_74X/'
 config.section_('User')
 config.section_('Site')
 config.Site.whitelist = ['T2_UK_London_IC', 'T2_CH_CERN', 'T2_FR_GRIF_LLR', 'T2_UK_SGrid_Bristol', 'T3_US_FNALLPC', 'T2_DE_DESY', 'T2_IT_Bari', 'T2_BE_IIHE', 'T2_US_UCSD', 'T2_US_MIT', 'T2_IT_Pisa', 'T2_US_Wisconsin', 'T2_US_Florida', 'T2_IT_Rome','T2_FR_IPHC']
@@ -51,10 +51,10 @@ if __name__ == '__main__':
     tasks.append(('SingleMuon-2015D-promptv4','/SingleMuon/Run2015D-PromptReco-v4/MINIAOD'))
     tasks.append(('SingleElectron-2015D-promptv4','/SingleElectron/Run2015D-PromptReco-v4/MINIAOD'))
     tasks.append(('MuonEG-2015D-promptv4','/MuonEG/Run2015D-PromptReco-v4/MINIAOD'))
-    tasks.append(('Tau-2015D-prompt','/Tau/Run2015D-PromptReco-v3/MINIAOD'))
-    tasks.append(('SingleMuon-2015D-prompt','/SingleMuon/Run2015D-PromptReco-v3/MINIAOD'))
-    tasks.append(('SingleElectron-2015D-prompt','/SingleElectron/Run2015D-PromptReco-v3/MINIAOD'))
-    tasks.append(('MuonEG-2015D-prompt','/MuonEG/Run2015D-PromptReco-v3/MINIAOD'))
+    tasks.append(('Tau-2015D-Oct05','/Tau/Run2015D-05Oct2015-v1/MINIAOD'))
+    tasks.append(('SingleMuon-2015D-Oct05','/SingleMuon/Run2015D-05Oct2015-v1/MINIAOD'))
+    tasks.append(('SingleElectron-2015D-Oct05','/SingleElectron/Run2015D-05Oct2015-v1/MINIAOD'))
+    tasks.append(('MuonEG-2015D-Oct05','/MuonEG/Run2015D-05Oct2015-v2/MINIAOD'))
 
 
     for task in tasks:

--- a/test/crab_higgstautau_spring15_miniAODv2.py
+++ b/test/crab_higgstautau_spring15_miniAODv2.py
@@ -2,7 +2,7 @@ from WMCore.Configuration import Configuration
 config = Configuration()
 config.section_('General')
 config.General.transferOutputs = True
-config.General.workArea='Oct15_MC_74X'
+config.General.workArea='Oct30_MC_74X'
 config.section_('JobType')
 config.JobType.psetName = '/afs/cern.ch/work/a/adewit/private/CMSSW_7_4_12/src/UserCode/ICHiggsTauTau/test/higgstautau_cfg_74X_Sep15.py'
 config.JobType.pluginName = 'Analysis'
@@ -14,7 +14,7 @@ config.section_('Data')
 config.Data.unitsPerJob = 1
 config.Data.splitting = 'FileBased'
 config.Data.publication = False
-config.Data.outLFNDirBase='/store/user/adewit/Oct15_MC_74X/'
+config.Data.outLFNDirBase='/store/user/adewit/Oct30_MC_74X/'
 config.section_('User')
 config.section_('Site')
 config.Site.whitelist = ['T2_UK_London_IC', 'T2_CH_CERN', 'T2_FR_GRIF_LLR', 'T2_UK_SGrid_Bristol', 'T3_US_FNALLPC', 'T2_DE_DESY', 'T2_IT_Bari', 'T2_BE_IIHE', 'T2_US_UCSD', 'T2_US_MIT', 'T2_IT_Pisa', 'T2_US_Wisconsin', 'T2_US_Florida', 'T2_IT_Rome', 'T2_RU_JINR','T2_FR_GRIF_IRFU','T2_ES_IFCA','T2_DE_RWTH']
@@ -41,40 +41,42 @@ if __name__ == '__main__':
     tasks=list()
 
 #Signal samples
-   # tasks.append(('GluGluHToTauTau_M-120-t3','/GluGluHToTauTau_M120_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('GluGluHToTauTau_M-125-t3','/GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('GluGluHToTauTau_M-130-t3','/GluGluHToTauTau_M130_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('VBFHToTauTau_M-120-t3','/VBFHToTauTau_M120_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('VBFHToTauTau_M-125-t3','/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('VBFHToTauTau_M-130-t3','/VBFHToTauTau_M130_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('SUSYGluGluToHToTauTau_M-500-t3','/SUSYGluGluToHToTauTau_M-500_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('SUSYGluGluToHToTauTau_M-1000-t3','/SUSYGluGluToHToTauTau_M-1000_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('SUSYGluGluToHToTauTau_M-160-t3','/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('GluGluHToTauTau_M-120','/GluGluHToTauTau_M120_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('GluGluHToTauTau_M-125','/GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('GluGluHToTauTau_M-130','/GluGluHToTauTau_M130_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('VBFHToTauTau_M-120','/VBFHToTauTau_M120_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('VBFHToTauTau_M-125','/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('VBFHToTauTau_M-130','/VBFHToTauTau_M130_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('SUSYGluGluToHToTauTau_M-500','/SUSYGluGluToHToTauTau_M-500_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('SUSYGluGluToHToTauTau_M-1000','/SUSYGluGluToHToTauTau_M-1000_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('SUSYGluGluToHToTauTau_M-160','/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
 #    tasks.append(('SUSYGluGluToBBHToTauTau_M-500','/SUSYGluGluToBBHToTauTau_M-500_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt35ns_MCRUN2_74_V9-v1/MINIAODSIM'))
 #    tasks.append(('SUSYGluGluToBBHToTauTau_M-1000','/SUSYGluGluToBBHToTauTau_M-1000_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt35ns_MCRUN2_74_V9-v1/MINIAODSIM'))
-   # tasks.append(('SUSYGluGluToBBHToTauTau_M-160-t3','/SUSYGluGluToBBHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-#    tasks.append(('WWinclusive','/WW_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt35ns_MCRUN2_74_V9-v1/MINIAODSIM'))
-#    tasks.append(('WZinclusive','/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt35ns_MCRUN2_74_V9-v1/MINIAODSIM'))
-    tasks.append(('ZZinclusive-t2','/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('SUSYGluGluToBBHToTauTau_M-160','/SUSYGluGluToBBHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WWinclusive','/WW_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WZinclusive','/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('ZZinclusive','/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
 #    tasks.append(('QCDFlat','/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/RunIISpring15DR74-Asympt35nsRaw_MCRUN2_74_V9-v3/MINIAODSIM'))
 #    tasks.append(('QCDMuEnr','/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt35ns_MCRUN2_74_V9-v1/MINIAODSIM'))
-   # tasks.append(('T-tW-t3','/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v2/MINIAODSIM'))
-    #tasks.append(('Tbar-tW-t4','/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('TT-t3','/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('TT-ext-t3','/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2_ext3-v1/MINIAODSIM'))
-   # tasks.append(('WWTo2L2Nu-t3', '/WWTo2L2Nu_13TeV-powheg/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-   # tasks.append(('WWTo4Q-t3', '/WWTo4Q_13TeV-powheg/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v2/MINIAODSIM'))
-   # tasks.append(('WWToLNuQQ-t3', '/WWToLNuQQ_13TeV-powheg/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-#    tasks.append(('ZZTo4L', '/ZZTo4L_13TeV_powheg_pythia8/RunIISpring15DR74-Asympt35ns_MCRUN2_74_V9-v1/MINIAODSIM'))
+    tasks.append(('T-tW','/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v2/MINIAODSIM'))
+    tasks.append(('Tbar-tW','/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('TT','/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('TT-ext','/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2_ext3-v1/MINIAODSIM'))
+    tasks.append(('WWTo2L2Nu', '/WWTo2L2Nu_13TeV-powheg/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WWTo4Q', '/WWTo4Q_13TeV-powheg/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v2/MINIAODSIM'))
+    tasks.append(('WWToLNuQQ', '/WWToLNuQQ_13TeV-powheg/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('ZZTo4L','/ZZTo4L_13TeV_powheg_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v2/MINIAODSIM'))
 #LO W+Jets
-#    tasks.append(('WJetsToLNu_HT100-200-t3', '/WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-#    tasks.append(('WJetsToLNu_HT200-400-t3', '/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-#    tasks.append(('WJetsToLNu_HT400-600-t3', '/WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-#    tasks.append(('WJetsToLNu_HT600-inf-t3', '/WJetsToLNu_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WJetsToLNu-LO', '/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WJetsToLNu_HT100-200', '/WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WJetsToLNu_HT200-400', '/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WJetsToLNu_HT400-600', '/WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WJetsToLNu_HT600-inf', '/WJetsToLNu_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
 #LO DY
-#    tasks.append(('DYJetsToLL_M-50-LO-t3', '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-#    tasks.append(('DYJetsToLL_M-50_HT100-200-t3', '/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-#    tasks.append(('DYJetsToLL_M-50_HT200-400-t3', '/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('DYJetsToLL_M-50-LO', '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('DYJetsToLL_M-50_HT100-200', '/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('DYJetsToLL_M-50_HT200-400', '/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('DYJetsToLL_M-50_HT600-Inf', '/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
 #
     for task in tasks:
         print task[0]

--- a/test/crab_higgstautau_spring15_miniAODv2_NLO.py
+++ b/test/crab_higgstautau_spring15_miniAODv2_NLO.py
@@ -2,7 +2,7 @@ from WMCore.Configuration import Configuration
 config = Configuration()
 config.section_('General')
 config.General.transferOutputs = True
-config.General.workArea='Oct15_MC_74X'
+config.General.workArea='Oct30_MC_74X'
 #config.General.requestName = 'May13_MC'
 config.section_('JobType')
 config.JobType.psetName = '/afs/cern.ch/work/a/adewit/private/CMSSW_7_4_12/src/UserCode/ICHiggsTauTau/test/higgstautau_cfg_74X_Sep15.py'
@@ -15,7 +15,7 @@ config.section_('Data')
 config.Data.unitsPerJob = 1
 config.Data.splitting = 'FileBased'
 config.Data.publication = False
-config.Data.outLFNDirBase='/store/user/adewit/Oct15_MC_74X/'
+config.Data.outLFNDirBase='/store/user/adewit/Oct30_MC_74X/'
 config.section_('User')
 config.section_('Site')
 config.Site.whitelist = ['T2_UK_London_IC', 'T2_CH_CERN', 'T2_FR_GRIF_LLR', 'T2_UK_SGrid_Bristol', 'T3_US_FNALLPC', 'T2_DE_DESY', 'T2_IT_Bari', 'T2_BE_IIHE', 'T2_US_UCSD', 'T2_US_MIT', 'T2_IT_Pisa', 'T2_US_Wisconsin', 'T2_US_Florida', 'T2_IT_Rome']
@@ -41,11 +41,17 @@ if __name__ == '__main__':
 
     tasks=list()
 
-    tasks.append(('WJetsToLNu-t3','/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
-    tasks.append(('DYJetsToLL-t3','/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WJetsToLNu','/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('DYJetsToLL','/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
     #tasks.append(('DYJetsToLL10-50','/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM'))
-    tasks.append(('TTJets-t3','/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v3/MINIAODSIM'))
-    tasks.append(('WZTo1L1Nu2Q-t3','/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('TTJets','/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v3/MINIAODSIM'))
+    tasks.append(('WZTo1L1Nu2Q','/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('WZTo2L2Q','/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('ZZTo2L2Q','/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('ZZTo2Q2Nu','/ZZTo2Q2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('ZZTo4Q','/ZZTo4Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
+    tasks.append(('T-tW-t','/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2_ext1-v1/MINIAODSIM'))
+    tasks.append(('T-tW-s','/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM'))
 
     for task in tasks:
         print task[0]

--- a/test/higgstautau_cfg_74X_Sep15.py
+++ b/test/higgstautau_cfg_74X_Sep15.py
@@ -10,7 +10,8 @@ opts = parser.VarParsing ('analysis')
 #opts.register('file', 'file:/afs/cern.ch/work/a/adewit/private/CMSSW_7_4_4/src/UserCode/ICHiggsTauTau/test/testinput.root', parser.VarParsing.multiplicity.singleton,
 #opts.register('file', 'file:/afs/cern.ch/work/a/adewit/private/CMSSW_7_4_5/src/UserCode/ICHiggsTauTau/test/TauDataTest.root', parser.VarParsing.multiplicity.singleton,
 opts.register('file',
-'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/SUSYGluGluToHToTauTau_M-1000_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/50000/9EF16FCE-E771-E511-AAB0-008CFA1979EC.root',parser.VarParsing.multiplicity.singleton,
+'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/10563B6E-D871-E511-9513-B499BAABD280.root',parser.VarParsing.multiplicity.singleton,
+#'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/SUSYGluGluToHToTauTau_M-1000_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/50000/9EF16FCE-E771-E511-AAB0-008CFA1979EC.root',parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/data/Run2015B/SingleElectron/MINIAOD/PromptReco-v1/000/251/163/00000/9C435096-9F26-E511-A1D7-02163E012AB6.root',parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/data/Run2015D/MuonEG/MINIAOD/PromptReco-v3/000/256/630/00000/24F810E0-335F-E511-94F4-02163E011C61.root', parser.VarParsing.multiplicity.singleton,
 #'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/00000/0014DC94-DC5C-E511-82FB-7845C4FC39F5.root', parser.VarParsing.multiplicity.singleton,
@@ -316,10 +317,18 @@ process.icVertexProducer = producers.icVertexProducer.clone(
   firstVertexOnly = cms.bool(True)
 )
 
+process.icGenVertexProducer = producers.icGenVertexProducer.clone(
+  input = cms.InputTag("prunedGenParticles")
+)
+
 
 process.icVertexSequence = cms.Sequence(
-  process.icVertexProducer
+  process.icVertexProducer+
+  process.icGenVertexProducer
 )
+
+if isData :
+  process.icVertexSequence.remove(process.icGenVertexProducer)
 
 ################################################################
 # PFCandidates
@@ -1249,6 +1258,7 @@ process.icPfMVAMetProducer = cms.EDProducer('ICPFMetProducer',
   includeMetUncertainties = cms.bool(False),
   metuncertainties = cms.vstring(),
   includeExternalMetsigMethod2 = cms.bool(False),
+  doGenMet = cms.bool(False),
   metsig = cms.PSet(
     metsig = cms.InputTag("METSignificance","METSignificance"),
     metsigcov00 = cms.InputTag("METSignificance", "CovarianceMatrix00"),


### PR DESCRIPTION
As do_metcorrections was already not expected by reco met producer the OptionNotSupported exceptions were unstable, fixed by removing these (and removing extraction of do_metuncertainties by reco met producer)
The met from pat producer is unaffected.