### PR TITLE
Storing LHE particles

### DIFF
--- a/plugins/ICGenParticleFromLHEParticlesProducer.cc
+++ b/plugins/ICGenParticleFromLHEParticlesProducer.cc
@@ -1,0 +1,65 @@
+#include "UserCode/ICHiggsTauTau/plugins/ICGenParticleFromLHEParticlesProducer.hh"
+#include <string>
+#include <vector>
+#include "Math/Vector4D.h"
+#include "Math/Vector4Dfwd.h"
+#include <bitset>
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "UserCode/ICHiggsTauTau/interface/StaticTree.hh"
+#include "UserCode/ICHiggsTauTau/interface/GenParticle.hh"
+#include "UserCode/ICHiggsTauTau/interface/city.h"
+#include "UserCode/ICHiggsTauTau/plugins/PrintConfigTools.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
+#include "UserCode/ICHiggsTauTau/plugins/Consumes.h"
+
+ICGenParticleFromLHEParticlesProducer::ICGenParticleFromLHEParticlesProducer(const edm::ParameterSet& config)
+    : input_(config.getParameter<edm::InputTag>("input")),
+      branch_(config.getParameter<std::string>("branch")){
+  consumes<LHEEventProduct>(input_);
+  particles_ = new std::vector<ic::GenParticle>();
+
+  PrintHeaderWithProduces(config, input_, branch_);
+}
+
+ICGenParticleFromLHEParticlesProducer::~ICGenParticleFromLHEParticlesProducer() { delete particles_; }
+
+void ICGenParticleFromLHEParticlesProducer::produce(edm::Event& event,
+                                    const edm::EventSetup& setup) {
+
+  edm::Handle<LHEEventProduct> lhe_handle;
+  event.getByLabel(input_, lhe_handle);
+  std::vector<lhef::HEPEUP::FiveVector> lheParticles = lhe_handle->hepeup().PUP;
+
+  particles_->clear();
+  particles_->resize(lheParticles.size(), ic::GenParticle());
+
+  ROOT::Math::PxPyPzEVector cand_;
+  for (unsigned i = 0; i < lheParticles.size(); ++i) {
+    ic::GenParticle& dest = particles_->at(i);
+    cand_ = ROOT::Math::PxPyPzEVector(lheParticles[i][0],lheParticles[i][1],lheParticles[i][2],lheParticles[i][3]);
+    dest.set_pt((cand_).Pt());
+    dest.set_eta((cand_).Eta());
+    dest.set_phi((cand_).Phi());
+    dest.set_energy((cand_).E());
+    dest.set_pdgid(lhe_handle->hepeup().IDUP[i]);
+    dest.set_status(lhe_handle->hepeup().ISTUP[i]);
+  }
+}
+
+void ICGenParticleFromLHEParticlesProducer::beginJob() {
+  ic::StaticTree::tree_->Branch(branch_.c_str(), &particles_);
+
+}
+
+void ICGenParticleFromLHEParticlesProducer::endJob() {}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(ICGenParticleFromLHEParticlesProducer);

--- a/plugins/ICGenParticleFromLHEParticlesProducer.hh
+++ b/plugins/ICGenParticleFromLHEParticlesProducer.hh
@@ -1,0 +1,35 @@
+#ifndef UserCode_ICHiggsTauTau_ICGenParticleFromLHEParticlesProducer_h
+#define UserCode_ICHiggsTauTau_ICGenParticleFromLHEParticlesProducer_h
+
+#include <memory>
+#include <vector>
+#include <string>
+#include "boost/functional/hash.hpp"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "UserCode/ICHiggsTauTau/interface/GenParticle.hh"
+
+/**
+ * @brief See documentation [here](\ref objs-genparticle)
+ */
+class ICGenParticleFromLHEParticlesProducer : public edm::EDProducer {
+ public:
+  explicit ICGenParticleFromLHEParticlesProducer(const edm::ParameterSet &);
+  ~ICGenParticleFromLHEParticlesProducer();
+
+ private:
+  virtual void beginJob();
+  virtual void produce(edm::Event &, const edm::EventSetup &);
+  virtual void endJob();
+
+  std::vector<ic::GenParticle> *particles_;
+  edm::InputTag input_;
+  std::string branch_;
+
+};
+
+#endif

--- a/python/default_producers_cfi.py
+++ b/python/default_producers_cfi.py
@@ -455,6 +455,14 @@ icGenParticleProducer = cms.EDProducer('ICGenParticleProducer',
 )
 ## [GenParticle]
 
+
+## [GenParticle from LHE]
+icGenParticleFromLHEParticlesProducer = cms.EDProducer('ICGenParticleFromLHEParticlesProducer',
+  branch  = cms.string("lheParticles"),
+  input   = cms.InputTag("externalLHEProducer")
+)
+## [GenParticle from LHE]
+
 icGenVertexProducer = cms.EDProducer('ICGenVertexProducer',
   branch = cms.string("genVertices"),
   input = cms.InputTag("genParticles"),


### PR DESCRIPTION
@amagnan this one's relevant for you:
This PR adds a producer to create an ic::GenParticle collection from the LHE particles, this is more flexible than calculating a bunch of quantities from the LHE particles and storing them in the EventInfo like we're doing now. We can eventually remove these: https://github.com/ajgilbert/ICHiggsTauTau/blob/master/src/EventInfo.cc#L13-L15 from the EventInfo and calculate them at analysis level (but for now they're still in there, I'll remove them in the not too distant future)