### PR TITLE
Fixing issue with boost::bind default arguments

### DIFF
--- a/Analysis/HiggsTauTau/src/HTTSequence.cc
+++ b/Analysis/HiggsTauTau/src/HTTSequence.cc
@@ -823,7 +823,7 @@ if(strategy_type==strategy::fall15&&!is_data&&js["do_btag_eff"].asBool()){
 SimpleFilter<PFJet> jetIDFilter = SimpleFilter<PFJet>("JetIDFilter")
 .set_input_label(jets_label);
 if(strategy_type == strategy::paper2013) {
-  jetIDFilter.set_predicate((bind(PFJetIDNoHFCut, _1)) && bind(PileupJetID, _1, pu_id_training));
+  jetIDFilter.set_predicate((bind(PFJetIDNoHFCut, _1)) && bind(PileupJetID, _1, pu_id_training, false));
 } else {
   jetIDFilter.set_predicate((bind(PFJetID2015, _1))); 
 }

--- a/Analysis/HiggsTauTau/test/HiggsTauTau.cpp
+++ b/Analysis/HiggsTauTau/test/HiggsTauTau.cpp
@@ -978,7 +978,7 @@ int main(int argc, char* argv[]){
   SimpleFilter<PFJet> jetIDFilter = SimpleFilter<PFJet>
     ("JetIDFilter")
     .set_input_label(jets_label)
-    .set_predicate((bind(PFJetIDNoHFCut, _1)) && bind(PileupJetID, _1, pu_id_training));
+    .set_predicate((bind(PFJetIDNoHFCut, _1)) && bind(PileupJetID, _1, pu_id_training, false));
 
   CopyCollection<PFJet>
     filteredJetCopyCollection("CopyFilteredJets",jets_label,"pfJetsPFlowFiltered");


### PR DESCRIPTION
Turns out setting default arguments doesn't work well in the boost version tied with older CMSSW releases, which Adinda and I were still using in places (e.g. 72X or 73X). Just running this small fix through a PR and the "please test" function to ensure it fixes things for all releases. @amagnan (and everyone else) it might be good to revert to the habit of doing this whenever you change anything which is outside of the HiggsNuNu area - this change to the arguments of the PileupJetID function in FnPredicates you committed earlier broke the compilation of the HiggsTauTau directory because we were in an older CMSSW release and definitely confused Adinda and myself for a while! 