### PR TITLE
ICTriggerPathProducer: print hash summary

### DIFF
--- a/Analysis/HiggsTauTau/test/PlotCompare.cpp
+++ b/Analysis/HiggsTauTau/test/PlotCompare.cpp
@@ -279,7 +279,7 @@ int main(int argc, char* argv[]){
   ntrees++; 
   }
 
-  double sep;  
+  double sep = 0.0;
   if(plots.size() == 2) {
     TH1 * plot_1 = elements[0].hist_ptr();   
     TH1 * plot_2 = elements[1].hist_ptr();

--- a/plugins/ICTriggerPathProducer.cc
+++ b/plugins/ICTriggerPathProducer.cc
@@ -136,7 +136,7 @@ void ICTriggerPathProducer::endJob() {
   // of the string hashes
   if (!save_strings_) {
     std::cout << std::string(78, '-') << "\n";
-    std::cout << boost::format("%56s  %20s\n")
+    std::cout << boost::format("%-56s  %20s\n")
         % "HLT Paths" % std::string("Hash Summmary");
     std::map<std::string, std::size_t>::const_iterator iter;
     for (iter = observed_paths_.begin(); iter != observed_paths_.end();

--- a/plugins/ICTriggerPathProducer.cc
+++ b/plugins/ICTriggerPathProducer.cc
@@ -116,8 +116,15 @@ void ICTriggerPathProducer::SetNameInfo(std::string name,
       }
     }
   }
-  if (save_strings_) path->set_name(name);
-  path->set_id(CityHash64(name));
+  std::size_t hash = CityHash64(name);
+  if (save_strings_) {
+    path->set_name(name);
+  } else {
+    if (!observed_paths_.count(name)) {
+      observed_paths_[name] = hash;
+    }
+  }
+  path->set_id(hash);
 }
 
 void ICTriggerPathProducer::beginJob() {
@@ -125,6 +132,18 @@ void ICTriggerPathProducer::beginJob() {
 }
 
 void ICTriggerPathProducer::endJob() {
+  // If the trigger path strings were not saved print a summary
+  // of the string hashes
+  if (!save_strings_) {
+    std::cout << std::string(78, '-') << "\n";
+    std::cout << boost::format("%56s  %20s\n")
+        % "HLT Paths" % std::string("Hash Summmary");
+    std::map<std::string, std::size_t>::const_iterator iter;
+    for (iter = observed_paths_.begin(); iter != observed_paths_.end();
+         ++iter) {
+      std::cout << boost::format("%-56s| %020i\n") % iter->first % iter->second;
+    }
+  }
 }
 
 // define this as a plug-in

--- a/plugins/ICTriggerPathProducer.hh
+++ b/plugins/ICTriggerPathProducer.hh
@@ -32,7 +32,7 @@ class ICTriggerPathProducer : public edm::EDProducer {
   bool split_version_;
   bool input_is_standalone_;
   edm::InputTag input_prescales_;
-
+  std::map<std::string, std::size_t> observed_paths_;
 };
 
 #endif


### PR DESCRIPTION
When the full trigger path strings aren't being saved will print a summary of the path name hashes at the end , e.g:

```
------------------------------------------------------------------------------
HLT Paths                                                        Hash Summmary
HLT_Dimuon20_Jpsi_v                                     | 06142835125249953426
HLT_Dimuon6_Jpsi_NoVertexing_v                          | 09826134308720555951
HLT_Dimuon8_PsiPrime_Barrel_v                           | 09540790213697327340
HLT_Dimuon8_Upsilon_Barrel_v                            | 07809485791521956029
... etc ...
```

This does seem to increase the processing time but not that significant in the grand scheme of things:

Before:
```
TimeReport ---------- Module Summary ---[Real sec]----
TimeReport  per event     per exec    per visit  Name
TimeReport   0.000175     0.000175     0.000175  icTriggerPathProducer
```
After:
```
TimeReport ---------- Module Summary ---[Real sec]----
TimeReport  per event     per exec    per visit  Name
TimeReport   0.000301     0.000301     0.000301  icTriggerPathProducer
```