### PR TITLE
Cleanup: plotting gen-level quantities to debug LO DY samples

### DIFF
--- a/Analysis/HiggsTauTau/interface/HTTWeights.h
+++ b/Analysis/HiggsTauTau/interface/HTTWeights.h
@@ -6,6 +6,8 @@
 #include "UserCode/ICHiggsTauTau/Analysis/Core/interface/ModuleBase.h"
 #include "UserCode/ICHiggsTauTau/Analysis/Utilities/interface/BTagWeight.h"
 #include "UserCode/ICHiggsTauTau/Analysis/HiggsTauTau/interface/HTTConfig.h"
+#include "PhysicsTools/FWLite/interface/TFileService.h"
+
 #include <string>
 
 
@@ -65,6 +67,7 @@ class HTTWeights : public ModuleBase {
   CLASS_MEMBER(HTTWeights, TH2D*, et_trig_data)
   CLASS_MEMBER(HTTWeights, TH2D*, mt_trig_mc)
   CLASS_MEMBER(HTTWeights, TH2D*, mt_trig_data)
+  CLASS_MEMBER(HTTWeights, fwlite::TFileService*, fs)
   TFile *muTauSF2011;
   TH2D *hist_muTauSF2011;
   TH2D *hist_muTauSF2011PFTau10;
@@ -81,6 +84,12 @@ class HTTWeights : public ModuleBase {
   mithep::TH2DAsymErr* ElectronFakeRateHist_PtEta;
   BTagWeight btag_weight;
   TF1 *tau_fake_weights_;
+
+  TTree *t_gen_info_;
+  int t_decay_;
+  float t_mll_;
+  int t_njets_;
+  float t_wt_;
 
   double f0_,f1_,f2_,f3_,f4_,n_inc_,n1_,n2_,n3_,n4_,w0_,w1_,w2_,w3_,w4_;
   double zf0_,zf1_,zf2_,zf3_,zf4_,zn_inc_,zn1_,zn2_,zn3_,zn4_,zn_hm_,zw0_,zw1_,zw2_,zw3_,zw4_;

--- a/Analysis/HiggsTauTau/scripts/launchGenJobs.py
+++ b/Analysis/HiggsTauTau/scripts/launchGenJobs.py
@@ -1,0 +1,64 @@
+import os
+import json
+import stat
+from math import ceil
+
+def file_len(fname):
+  with open(fname) as f:
+    for i, l in enumerate(f):
+      pass
+    return i + 1
+
+
+JOB_PROTO="""#!/bin/bash
+export X509_USER_PROXY=$HOME/.globus/user_proxy.pem
+source /usr/share/Modules/init/bash
+module use -a /afs/desy.de/group/cms/modulefiles/; module load cmssw
+cd %(PWD)s
+export SCRAM_ARCH=%(SCRAM_ARCH)s
+eval `scramv1 runtime -sh`
+%(INPUT)s
+"""
+
+basedir = '%s/src/UserCode/ICHiggsTauTau/Analysis/HiggsTauTau' % os.environ[
+    'CMSSW_BASE']
+
+PROD = 'Mar05_MC_76X'
+MAX_EVTS = -1
+FILES_PER_JOB = 200
+
+
+SAMPLES = [
+  'DY1JetsToLL_M-50-LO',
+  'DY2JetsToLL_M-50-LO',
+  'DY3JetsToLL_M-50-LO',
+  'DY4JetsToLL_M-50-LO',
+  'DYJetsToLL_M-150-LO',
+  'DYJetsToLL_M-50-LO-ext'
+]
+
+for sa in SAMPLES:
+    filelist = '%s/filelists/%s_%s.dat' % (basedir, PROD, sa)
+    nfiles = file_len(filelist)
+    njobs = int(ceil(float(nfiles)/float(FILES_PER_JOB)))
+    for n in xrange(njobs):
+        cfg = {
+            'output': '%s_%i.root' % (sa, n),
+            'filelist': filelist,
+            'file_offset': n,
+            'file_step': njobs,
+            'max_events': MAX_EVTS,
+            'sample_name': sa,
+            "file_prefix": "root://xrootd.grid.hep.ph.ic.ac.uk//store/user/adewit/Mar05_MC_76X"
+        }
+        cmd = """%s/bin/GenWeightStudy '%s' | tee %s_%i.log""" % (basedir, json.dumps(cfg), sa, n)
+        fname = 'job_%s_%i.sh' % (sa, n)
+        with open(fname, "w") as outfile:
+            print 'Creating job script %s' % fname 
+            outfile.write(JOB_PROTO % ({
+               'PWD': os.environ['PWD'],
+               'SCRAM_ARCH': os.environ['SCRAM_ARCH'],
+               'INPUT': cmd
+              }))
+        st = os.stat(fname)
+        os.chmod(fname, st.st_mode | stat.S_IEXEC)

--- a/Analysis/HiggsTauTau/scripts/plotGenWeights.py
+++ b/Analysis/HiggsTauTau/scripts/plotGenWeights.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+import ROOT
+import CombineHarvester.CombineTools.plotting as plot
+from UserCode.ICHiggsTauTau.uncertainties import ufloat
+import UserCode.ICHiggsTauTau.MultiDraw
+import argparse
+
+
+def Rate(hist):
+    err = ROOT.Double()
+    integral = hist.IntegralAndError(0, hist.GetNbinsX() + 1, err)
+    return ufloat(integral, err)
+
+# Boilerplate
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(ROOT.kTRUE)
+plot.ModTDRStyle()
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--var', default='mll(20,0,500)')
+parser.add_argument('--selection', default='1')
+parser.add_argument('--x-title', default='m_{ll}^{gen} (GeV)')
+parser.add_argument('--ratio-range', default='0.69,1.31')
+parser.add_argument('--title-right', default='')
+parser.add_argument('--title-left', default='')
+parser.add_argument('--output', default='mt_dist')
+parser.add_argument('--norm', action='store_true')
+parser.add_argument('--type', default=0, type=int)
+
+
+
+args = parser.parse_args()
+
+path = 'results'
+
+files = [
+    'DYJetsToLL_M-50-LO-ext',
+    'DY1JetsToLL_M-50-LO',
+    'DY2JetsToLL_M-50-LO',
+    'DY3JetsToLL_M-50-LO',
+    'DY4JetsToLL_M-50-LO',
+    'DYJetsToLL_M-150-LO'
+]
+
+# Uncomment to just print the sample yields
+# for f in files:
+#     fin = ROOT.TFile('%s/%s.root' % (path, f))
+#     t = fin.Get('genweights')
+#     print '%s: %i' % (f, t.GetEntries())
+
+
+ROOT.TH1.SetDefaultSumw2(True) # Why do I need to do this here?
+
+if args.type == 0:
+    ch_stitched = ROOT.TChain('genweights')
+    for f in files:
+        ch_stitched.Add('%s/%s.root' % (path, f))
+
+    ch_inc = ROOT.TChain('genweights')
+    ch_inc.Add('%s/%s.root' % (path, 'DYJetsToLL_M-50-LO-ext'))
+
+    res_stitched = ch_stitched.MultiDraw([(args.var, 'wt*(%s)' % args.selection)])
+    res_inc = ch_inc.MultiDraw([(args.var, '1*(%s)' % args.selection)])
+elif args.type == 1:
+    res = []
+    for f in files:
+        fin = ROOT.TFile('%s/%s.root' % (path, f))
+        t = fin.Get('genweights')
+        res.extend(t.MultiDraw([(args.var, '1*(%s)' % args.selection)]))
+
+canv = ROOT.TCanvas(args.output, args.output)
+pads = plot.TwoPadSplit(0.30, 0.01, 0.01)
+
+legend = ROOT.TLegend(0.50, 0.75, 0.93, 0.93, '', 'NBNDC')
+
+if args.type == 0:
+    plot.Set(res_inc[0], LineColor=ROOT.kBlack, LineWidth=3)
+    plot.Set(res_stitched[0], LineColor=ROOT.kRed, LineWidth=3)
+    legend.AddEntry(res_inc[0], 'Inclusive', 'L')
+    legend.AddEntry(res_stitched[0], 'Stitched', 'L')
+    res_inc[0].Draw('SAME')
+    res_stitched[0].Draw('SAME')
+elif args.type == 1:
+    cols = [28, 2, 4, 6, 8, 9, 30, 40, 46, 48, 1]
+    for i, f in enumerate(files):
+        plot.Set(res[i], LineColor=cols.pop(), LineWidth=3)
+        if args.norm and res[i].Integral(0, res[i].GetNbinsX() + 1) > 0.:
+            res[i].Scale(1 / res[i].Integral(0, res[i].GetNbinsX() + 1))
+        legend.AddEntry(res[i], f, 'L')
+        res[i].Draw('SAME')
+
+plot.FixTopRange(pads[0], plot.GetPadYMax(pads[0]), 0.40)
+legend.Draw()
+
+axis = plot.GetAxisHist(pads[0])
+plot.Set(axis.GetXaxis(), Title=args.x_title)
+plot.Set(axis.GetYaxis(), Title='Events')
+
+rmin = float(args.ratio_range.split(',')[0])
+rmax = float(args.ratio_range.split(',')[1])
+pads[1].cd()
+pads[1].SetGrid(0, 1)
+if args.type == 0:
+    ratio_hist = res_stitched[0].Clone()
+    ratio_hist.Divide(res_inc[0])
+    ratio_hist.Draw('SAME')
+    plot.SetupTwoPadSplitAsRatio(
+        pads, plot.GetAxisHist(
+            pads[0]), plot.GetAxisHist(pads[1]), 'Stitched/Inc', True, rmin, rmax)
+elif args.type == 1:
+    ratios = []
+    for i, f in enumerate(files):
+        if i == 0:
+            continue
+        ratios.append(res[i].Clone())
+        ratios[-1].Divide(res[0])
+        ratios[-1].Draw('SAME')
+    plot.SetupTwoPadSplitAsRatio(
+        pads, plot.GetAxisHist(
+            pads[0]), plot.GetAxisHist(pads[1]), 'Ratio/Inc', True, rmin, rmax)
+
+plot.DrawTitle(pads[0], args.title_left, 1)
+plot.DrawTitle(pads[0], args.title_right, 3)
+
+canv.Print('.pdf')
+canv.Print('.png')

--- a/Analysis/HiggsTauTau/test/GenWeightStudy.cpp
+++ b/Analysis/HiggsTauTau/test/GenWeightStudy.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include "PhysicsTools/FWLite/interface/TFileService.h"
+#include "Core/interface/AnalysisBase.h"
+#include "Utilities/interface/JsonTools.h"
+#include "Utilities/interface/FnRootTools.h"
+#include "HiggsTauTau/interface/WJetsStudy.h"
+#include "HiggsTauTau/interface/HTTWeights.h"
+
+
+using std::string;
+using std::vector;
+
+int main(int argc, char* argv[]) {
+
+  Json::Value js = ic::MergedJson(argc, argv);
+
+  fwlite::TFileService* fs =
+      new fwlite::TFileService((js["output"].asString()));
+
+  vector<string> files = ic::ParseFileLines(js["filelist"].asString());
+  vector<string> do_files;
+  unsigned file_offset = js.get("file_offset", 0).asUInt();
+  unsigned file_step = js.get("file_step", 1).asUInt();
+  for (auto & f : files) f = js.get("file_prefix", std::string("")).asString() + f;
+
+  for (unsigned i = file_offset; i < files.size(); i += file_step) {
+    do_files.push_back(files[i]);
+  }
+
+  ic::AnalysisBase analysis("GenWeightStudy", do_files, "icEventProducer/EventTree",
+                            js["max_events"].asInt64());
+  analysis.SetTTreeCaching(true);
+  analysis.StopOnFileFailure(true);
+  analysis.RetryFileAfterFailure(7, 3);
+  analysis.CalculateTimings(js.get("timings", false).asBool());
+
+  ic::HTTWeights httWeights = ic::HTTWeights("HTTWeights")
+    .set_jets_label("ak4PFJetsCHS")
+    .set_ditau_label("ditau")
+    .set_fs(fs);
+
+  httWeights.set_do_dy_soup_high_mass(true);
+  httWeights.SetDYInputCrossSectionsHighMass(4954, 1012.5, 332.8, 101.8,54.8,6.7); //Target fractions are xs_n-jet/xs_inclusive
+  httWeights.SetDYInputYieldsHighMass(239058696,65314144 , 20019059, 5701878, 4189017, 6079415);
+
+  analysis.AddModule(&httWeights);
+
+  analysis.RunAnalysis();
+
+  delete fs;
+
+  return 0;
+}


### PR DESCRIPTION
This was a massive hack to study the problem with the exclusive DY samples having different m_ll distributions in the same phase space. Clearly can't merge like this because I decided to create a small TTree in HTTWeights with the info - but could spin this into a separate module if we want to keep this perhaps.