### PR TITLE
Fixing trigger object producer

### DIFF
--- a/plugins/ICTriggerObjectProducer.cc
+++ b/plugins/ICTriggerObjectProducer.cc
@@ -59,16 +59,18 @@ void ICTriggerObjectProducer::produce(edm::Event& event,
 
     // Find the full label of the chosen HLT path (i.e. with the version number)
     bool fired = true;
+    bool path_found = false;
     std::string full_name;
     for (unsigned i = 0; i < paths->size(); ++i) {
       std::string const& name = paths->at(i).name();
       if (name.find(hlt_path_) != name.npos) {
         full_name = name;
+        path_found = true;
         if (store_only_if_fired_ && !(paths->at(i).wasAccept())) fired = false;
         break;  // Stop loop after we find the first match
       }
     }
-    if (!fired) return;
+    if (!fired || !path_found) return;
 
     // Get a vector of the objects used in the chosen path
     pat::TriggerObjectRefVector objects =
@@ -108,6 +110,7 @@ void ICTriggerObjectProducer::produce(edm::Event& event,
     edm::TriggerNames const& names = event.triggerNames(*trigres_handle);
 
     bool fired = true;
+    bool path_found = false;
     std::string full_name;
 
     for (unsigned int i = 0, n = trigres_handle->size(); i < n; ++i) {
@@ -115,11 +118,12 @@ void ICTriggerObjectProducer::produce(edm::Event& event,
       // std::cout << i << "\t" << name << "\n";
       if (name.find(hlt_path_) != name.npos) {
         full_name = name;
+        path_found = true;
         if (store_only_if_fired_ && !(trigres_handle->accept(i))) fired = false;
         break;  // Stop loop after we find the first match
       }
     }
-    if (!fired) return;
+    if (!fired || !path_found) return;
 
     // Have to use the HLTConfigProvider to get the list of object-producing
     // filter modules that were run in this path

--- a/plugins/ICTriggerObjectProducer.cc
+++ b/plugins/ICTriggerObjectProducer.cc
@@ -142,7 +142,7 @@ void ICTriggerObjectProducer::produce(edm::Event& event,
       // was only introduced in CMSSW_7_0_5
       src.unpackPathNames(names);
 #endif
-      std::vector<std::string> const& pathnames = src.pathNames();
+      std::vector<std::string> const& pathnames = src.pathNames(false,false);
       bool obj_in_path = false;
       for (unsigned j = 0; j < pathnames.size(); ++j) {
         if (full_name == pathnames[j]) {

--- a/test/crab_higgstautau_2016.py
+++ b/test/crab_higgstautau_2016.py
@@ -7,7 +7,7 @@ config.section_('JobType')
 config.JobType.psetName = '/afs/cern.ch/work/a/adewit/private/CMSSW_8_0_9/src/UserCode/ICHiggsTauTau/test/higgstautau_cfg_80X_Apr16.py'
 config.JobType.pluginName = 'Analysis'
 config.JobType.outputFiles = ['EventTree.root']
-config.JobType.inputFiles = ['Spring16_25nsV3_DATA.db']
+#config.JobType.inputFiles = ['Spring16_25nsV3_DATA.db']
 config.JobType.pyCfgParams = ['release=80XMINIAOD','isData=1','doHT=0', 'globalTag=80X_dataRun2_Prompt_ICHEP16JEC_v0']
 config.section_('Data')
 #config.Data.inputDataset = 'DUMMY'
@@ -19,7 +19,7 @@ config.Data.ignoreLocality= True
 config.Data.outLFNDirBase='/store/user/adewit/July08_Data_80X/'
 config.section_('User')
 config.section_('Site')
-config.Site.whitelist = ['T2_UK_London_IC', 'T2_CH_CERN', 'T2_FR_GRIF_LLR', 'T2_UK_SGrid_Bristol', 'T3_US_FNALLPC', 'T2_DE_DESY', 'T2_IT_Bari', 'T2_BE_IIHE', 'T2_US_UCSD', 'T2_US_MIT', 'T2_IT_Pisa', 'T2_US_Wisconsin', 'T2_US_Florida', 'T2_IT_Rome','T2_FR_IPHC','T2_UK_London_Brunel']
+config.Site.whitelist = ['T2_UK_London_IC', 'T2_CH_CERN', 'T2_FR_GRIF_LLR', 'T2_UK_SGrid_Bristol', 'T3_US_FNALLPC', 'T2_DE_DESY', 'T2_IT_Bari', 'T2_BE_IIHE', 'T2_US_UCSD', 'T2_US_MIT', 'T2_US_Wisconsin', 'T2_US_Florida', 'T2_IT_Rome','T2_FR_IPHC','T2_UK_London_Brunel']
 config.Site.storageSite = 'T2_UK_London_IC'
 
 if __name__ == '__main__':
@@ -42,14 +42,18 @@ if __name__ == '__main__':
 
     tasks=list()
 
-    tasks.append(('SingleElectronB','/SingleElectron/Run2016B-PromptReco-v2/MINIAOD'))
-    tasks.append(('SingleMuonB','/SingleMuon/Run2016B-PromptReco-v2/MINIAOD'))
-    tasks.append(('TauB','/Tau/Run2016B-PromptReco-v2/MINIAOD'))
-    tasks.append(('MuonEGB','/MuonEG/Run2016B-PromptReco-v2/MINIAOD'))
-    tasks.append(('SingleElectronC','/SingleElectron/Run2016C-PromptReco-v2/MINIAOD'))
-    tasks.append(('SingleMuonC','/SingleMuon/Run2016C-PromptReco-v2/MINIAOD'))
-    tasks.append(('TauC','/Tau/Run2016C-PromptReco-v2/MINIAOD'))
-    tasks.append(('MuonEGC','/MuonEG/Run2016C-PromptReco-v2/MINIAOD'))
+    tasks.append(('SingleElectronB-v2','/SingleElectron/Run2016B-PromptReco-v2/MINIAOD'))
+    tasks.append(('SingleMuonB-v2','/SingleMuon/Run2016B-PromptReco-v2/MINIAOD'))
+    tasks.append(('TauB-v2','/Tau/Run2016B-PromptReco-v2/MINIAOD'))
+    tasks.append(('MuonEGB-v2','/MuonEG/Run2016B-PromptReco-v2/MINIAOD'))
+    tasks.append(('SingleElectronC-v2','/SingleElectron/Run2016C-PromptReco-v2/MINIAOD'))
+    tasks.append(('SingleMuonC-v2','/SingleMuon/Run2016C-PromptReco-v2/MINIAOD'))
+    tasks.append(('TauC-v2','/Tau/Run2016C-PromptReco-v2/MINIAOD'))
+    tasks.append(('MuonEGC-v2','/MuonEG/Run2016C-PromptReco-v2/MINIAOD'))
+    tasks.append(('SingleElectronD','/SingleElectron/Run2016D-PromptReco-v2/MINIAOD'))
+    tasks.append(('SingleMuonD','/SingleMuon/Run2016D-PromptReco-v2/MINIAOD'))
+    tasks.append(('TauD','/Tau/Run2016D-PromptReco-v2/MINIAOD'))
+    tasks.append(('MuonEGD','/MuonEG/Run2016D-PromptReco-v2/MINIAOD'))
 
     for task in tasks:
         print task[0]

--- a/test/crab_higgstautau_2016.py
+++ b/test/crab_higgstautau_2016.py
@@ -2,13 +2,13 @@ from WMCore.Configuration import Configuration
 config = Configuration()
 config.section_('General')
 config.General.transferOutputs = True
-config.General.workArea='June29_Data_80X'
+config.General.workArea='July08_Data_80X'
 config.section_('JobType')
 config.JobType.psetName = '/afs/cern.ch/work/a/adewit/private/CMSSW_8_0_9/src/UserCode/ICHiggsTauTau/test/higgstautau_cfg_80X_Apr16.py'
 config.JobType.pluginName = 'Analysis'
 config.JobType.outputFiles = ['EventTree.root']
 config.JobType.inputFiles = ['Spring16_25nsV3_DATA.db']
-config.JobType.pyCfgParams = ['release=80XMINIAOD','isData=1','doHT=0', 'globalTag=80X_dataRun2_Prompt_v8']
+config.JobType.pyCfgParams = ['release=80XMINIAOD','isData=1','doHT=0', 'globalTag=80X_dataRun2_Prompt_ICHEP16JEC_v0']
 config.section_('Data')
 #config.Data.inputDataset = 'DUMMY'
 config.Data.unitsPerJob = 30000 
@@ -16,7 +16,7 @@ config.Data.unitsPerJob = 30000
 config.Data.splitting = 'EventAwareLumiBased'
 config.Data.publication = False
 config.Data.ignoreLocality= True
-config.Data.outLFNDirBase='/store/user/adewit/June29_Data_80X/'
+config.Data.outLFNDirBase='/store/user/adewit/July08_Data_80X/'
 config.section_('User')
 config.section_('Site')
 config.Site.whitelist = ['T2_UK_London_IC', 'T2_CH_CERN', 'T2_FR_GRIF_LLR', 'T2_UK_SGrid_Bristol', 'T3_US_FNALLPC', 'T2_DE_DESY', 'T2_IT_Bari', 'T2_BE_IIHE', 'T2_US_UCSD', 'T2_US_MIT', 'T2_IT_Pisa', 'T2_US_Wisconsin', 'T2_US_Florida', 'T2_IT_Rome','T2_FR_IPHC','T2_UK_London_Brunel']

--- a/test/crab_higgstautau_Spring16_miniAOD.py
+++ b/test/crab_higgstautau_Spring16_miniAOD.py
@@ -1,0 +1,74 @@
+from WMCore.Configuration import Configuration
+config = Configuration()
+config.section_('General')
+config.General.transferOutputs = True
+config.General.workArea='July08_MC_80X'
+config.section_('JobType')
+config.JobType.psetName = '/afs/cern.ch/work/a/adewit/private/CMSSW_8_0_9/src/UserCode/ICHiggsTauTau/test/higgstautau_cfg_80X_Apr16.py'
+config.JobType.pluginName = 'Analysis'
+config.JobType.outputFiles = ['EventTree.root']
+#config.JobType.inputFiles = ['Spring16_25nsV3_MC.db']
+config.JobType.pyCfgParams = ['release=80XMINIAOD','isData=0','doHT=0', 'globalTag=80X_mcRun2_asymptotic_2016_miniAODv2_v1']
+config.section_('Data')
+#config.Data.inputDataset = 'DUMMY'
+config.Data.unitsPerJob = 30000 
+#config.Data.unitsPerJob = 1
+config.Data.splitting = 'EventAwareLumiBased'
+config.Data.publication = False
+#config.Data.ignoreLocality= True
+config.Data.outLFNDirBase='/store/user/adewit/July08_MC_80X/'
+config.section_('User')
+config.section_('Site')
+config.Site.whitelist = ['T2_UK_London_IC', 'T2_CH_CERN', 'T2_FR_GRIF_LLR', 'T2_UK_SGrid_Bristol', 'T3_US_FNALLPC', 'T2_DE_DESY', 'T2_IT_Bari', 'T2_BE_IIHE', 'T2_US_UCSD', 'T2_US_MIT', 'T2_US_Wisconsin', 'T2_US_Florida', 'T2_IT_Rome','T2_FR_IPHC','T2_UK_London_Brunel']
+config.Site.storageSite = 'T2_UK_London_IC'
+
+if __name__ == '__main__':
+
+    from CRABAPI.RawCommand import crabCommand
+    from httplib import HTTPException
+
+    # We want to put all the CRAB project directories from the tasks we submit here into one common directory.
+    # That's why we need to set this parameter (here or above in the configuration file, it does not matter, we will not overwrite it).
+
+    def submit(config):
+        try:
+            crabCommand('submit', config = config)
+        except HTTPException, hte:
+            print hte.headers
+
+    #############################################################################################
+    ## From now on that's what users should modify: this is the a-la-CRAB2 configuration part. ##
+    #############################################################################################
+
+    tasks=list()
+
+    tasks.append(('GluGluHToTauTau_M-125','/GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('VBFHToTauTau_M-125','/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('WminusHToTauTau_M-125','/WminusHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('ZHToTauTau_M-125','/ZHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('SUSYGluGluToHToTauTau_M-160','/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('SUSYGluGluToHToTauTau_M-500','/SUSYGluGluToHToTauTau_M-500_TuneCUETP8M1_13TeV-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('SUSYGluGluToBBHToTauTau_M-160','/SUSYGluGluToBBHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('SUSYGluGluToBBHToTauTau_M-500','/SUSYGluGluToBBHToTauTau_M-500_TuneCUETP8M1_13TeV-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('VVTo2L2Nu','/VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('ZZTo2L2Q','/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('WWTo1L1Nu2Q','/WWTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('WZTo2L2Q','/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('WZTo1L3Nu','/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('WZTo1L1Nu2Q','/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('Tbar-tW','/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('T-tW','/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('Tbar-t','/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('T-t','/ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('TT','/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3_ext3-v1/MINIAODSIM'))
+    tasks.append(('DYJetsToLL','/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('WJetsToLNu','/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+
+    for task in tasks:
+        print task[0]
+        config.General.requestName = task[0]
+        config.Data.inputDataset = task[1]
+        submit(config)
+
+
+

--- a/test/crab_higgstautau_Spring16_miniAOD_HTBinned.py
+++ b/test/crab_higgstautau_Spring16_miniAOD_HTBinned.py
@@ -1,0 +1,64 @@
+from WMCore.Configuration import Configuration
+config = Configuration()
+config.section_('General')
+config.General.transferOutputs = True
+config.General.workArea='July08_MC_80X'
+config.section_('JobType')
+config.JobType.psetName = '/afs/cern.ch/work/a/adewit/private/CMSSW_8_0_9/src/UserCode/ICHiggsTauTau/test/higgstautau_cfg_80X_Apr16.py'
+config.JobType.pluginName = 'Analysis'
+config.JobType.outputFiles = ['EventTree.root']
+#config.JobType.inputFiles = ['Spring16_25nsV3_MC.db']
+config.JobType.pyCfgParams = ['release=80XMINIAOD','isData=0','doHT=1', 'globalTag=80X_mcRun2_asymptotic_2016_miniAODv2_v1']
+config.section_('Data')
+#config.Data.inputDataset = 'DUMMY'
+config.Data.unitsPerJob = 30000 
+#config.Data.unitsPerJob = 1
+config.Data.splitting = 'EventAwareLumiBased'
+config.Data.publication = False
+#config.Data.ignoreLocality= True
+config.Data.outLFNDirBase='/store/user/adewit/July08_MC_80X/'
+config.section_('User')
+config.section_('Site')
+config.Site.whitelist = ['T2_UK_London_IC', 'T2_CH_CERN', 'T2_FR_GRIF_LLR', 'T2_UK_SGrid_Bristol', 'T3_US_FNALLPC', 'T2_DE_DESY', 'T2_IT_Bari', 'T2_BE_IIHE', 'T2_US_UCSD', 'T2_US_MIT',  'T2_US_Wisconsin', 'T2_US_Florida', 'T2_IT_Rome','T2_FR_IPHC','T2_UK_London_Brunel']
+config.Site.storageSite = 'T2_UK_London_IC'
+
+if __name__ == '__main__':
+
+    from CRABAPI.RawCommand import crabCommand
+    from httplib import HTTPException
+
+    # We want to put all the CRAB project directories from the tasks we submit here into one common directory.
+    # That's why we need to set this parameter (here or above in the configuration file, it does not matter, we will not overwrite it).
+
+    def submit(config):
+        try:
+            crabCommand('submit', config = config)
+        except HTTPException, hte:
+            print hte.headers
+
+    #############################################################################################
+    ## From now on that's what users should modify: this is the a-la-CRAB2 configuration part. ##
+    #############################################################################################
+
+    tasks=list()
+  
+    tasks.append(('WJetsToLNu-LO','/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v2/MINIAODSIM'))
+    tasks.append(('W1JetsToLNu-LO','/W1JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('W2JetsToLNu-LO','/W2JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('W3JetsToLNu-LO','/W3JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('W4JetsToLNu-LO','/W4JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('DYJetsToLL-LO','/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3_ext1-v1/MINIAODSIM'))
+    tasks.append(('DY1JetsToLL-LO','/DY1JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('DY2JetsToLL-LO','/DY2JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('DY3JetsToLL-LO','/DY3JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+    tasks.append(('DY4JetsToLL-LO','/DY4JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM'))
+
+
+    for task in tasks:
+        print task[0]
+        config.General.requestName = task[0]
+        config.Data.inputDataset = task[1]
+        submit(config)
+
+
+

--- a/test/higgstautau_cfg_80X_Apr16.py
+++ b/test/higgstautau_cfg_80X_Apr16.py
@@ -37,8 +37,8 @@ opts.register('file',
 #opts.register('file', 'root://xrootd.unl.edu//store/mc/Phys14DR/GluGluToHToTauTau_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_tsg_PHYS14_25_V1-v1/00000/2405749F-8B6F-E411-88EE-848F69FD2910.root', parser.VarParsing.multiplicity.singleton,
 #opts.register('file', 'root://xrootd.unl.edu//store/mc/Phys14DR/VBF_HToTauTau_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU40bx25_PHYS14_25_V1-v1/00000/36224FE2-0571-E411-9664-00266CFAE30C.root', parser.VarParsing.multiplicity.singleton,
     parser.VarParsing.varType.string, "input file")
-#opts.register('globalTag', '80X_mcRun2_asymptotic_2016_miniAODv2', parser.VarParsing.multiplicity.singleton,
-opts.register('globalTag', '80X_dataRun2_Prompt_v8', parser.VarParsing.multiplicity.singleton,
+#opts.register('globalTag', '80X_mcRun2_asymptotic_2016_miniAODv2_v1', parser.VarParsing.multiplicity.singleton,
+opts.register('globalTag', '80X_dataRun2_Prompt_ICHEP16JEC_v0', parser.VarParsing.multiplicity.singleton,
     parser.VarParsing.varType.string, "global tag")
 opts.register('isData', 1, parser.VarParsing.multiplicity.singleton,
     parser.VarParsing.varType.int, "Process as data?")
@@ -104,51 +104,51 @@ process.options   = cms.untracked.PSet(
 ################################################################
 process.load("CondCore.CondDB.CondDB_cfi")
 from CondCore.CondDB.CondDB_cfi import *
-if not isData:
-  process.jec = cms.ESSource("PoolDBESSource",
-    DBParameters = cms.PSet(
-     messageLevel = cms.untracked.int32(0)
-    ),
-    timetype = cms.string('runnumber'),
-    toGet = cms.VPSet(
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Spring16_25nsV3_MC_AK4PF'),
-      label = cms.untracked.string('AK4PF')
-      ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Spring16_25nsV3_MC_AK4PFchs'),
-      label = cms.untracked.string('AK4PFchs')
-      ),
-    ),
-    connect = cms.string('sqlite:Spring16_25nsV3_MC.db')
-  )
+#if not isData:
+#  process.jec = cms.ESSource("PoolDBESSource",
+#    DBParameters = cms.PSet(
+#     messageLevel = cms.untracked.int32(0)
+#    ),
+#    timetype = cms.string('runnumber'),
+#    toGet = cms.VPSet(
+#    cms.PSet(
+#      record = cms.string('JetCorrectionsRecord'),
+#      tag = cms.string('JetCorrectorParametersCollection_Spring16_25nsV3_MC_AK4PF'),
+#      label = cms.untracked.string('AK4PF')
+#      ),
+#    cms.PSet(
+#      record = cms.string('JetCorrectionsRecord'),
+#      tag = cms.string('JetCorrectorParametersCollection_Spring16_25nsV3_MC_AK4PFchs'),
+#      label = cms.untracked.string('AK4PFchs')
+#      ),
+#    ),
+#    connect = cms.string('sqlite:Spring16_25nsV3_MC.db')
+#  )
+#
+#  process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
 
-  process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
-
-else :
-  process.jec = cms.ESSource("PoolDBESSource",
-    DBParameters = cms.PSet(
-     messageLevel = cms.untracked.int32(0)
-    ),
-    timetype = cms.string('runnumber'),
-    toGet = cms.VPSet(
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Spring16_25nsV3_DATA_AK4PF'),
-      label = cms.untracked.string('AK4PF')
-      ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Spring16_25nsV3_DATA_AK4PFchs'),
-      label = cms.untracked.string('AK4PFchs')
-      ),
-    ),
-    connect = cms.string('sqlite:Spring16_25nsV3_DATA.db')
-  )
-
-  process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+#else :
+#  process.jec = cms.ESSource("PoolDBESSource",
+#    DBParameters = cms.PSet(
+#     messageLevel = cms.untracked.int32(0)
+#    ),
+#    timetype = cms.string('runnumber'),
+#    toGet = cms.VPSet(
+#    cms.PSet(
+#      record = cms.string('JetCorrectionsRecord'),
+#      tag = cms.string('JetCorrectorParametersCollection_Spring16_25nsV3_DATA_AK4PF'),
+#      label = cms.untracked.string('AK4PF')
+#      ),
+#    cms.PSet(
+#      record = cms.string('JetCorrectionsRecord'),
+#      tag = cms.string('JetCorrectorParametersCollection_Spring16_25nsV3_DATA_AK4PFchs'),
+#      label = cms.untracked.string('AK4PFchs')
+#      ),
+#    ),
+#    connect = cms.string('sqlite:Spring16_25nsV3_DATA.db')
+#  )
+#
+#  process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(
 #process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(
 #'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/QCD_HT200to300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/30000/D61F7B94-676F-E511-9970-00221981B434.root',
@@ -1946,13 +1946,13 @@ process.icIsoMu22ObjectProducer = producers.icTriggerObjectProducer.clone(
     storeOnlyIfFired = cms.bool(False)
     )
 
-#process.icIsoMu22Eta2p1ObjectProducer = producers.icTriggerObjectProducer.clone(
-#    input   = cms.InputTag("patTriggerEvent"),
-#    branch = cms.string("triggerObjectsIsoMu22Eta2p1"),
-#    hltPath = cms.string("HLT_IsoMu22_eta2p1_v"),
-#    inputIsStandAlone = cms.bool(False),
-#    storeOnlyIfFired = cms.bool(False)
-#    )
+process.icIsoMu22Eta2p1ObjectProducer = producers.icTriggerObjectProducer.clone(
+    input   = cms.InputTag("patTriggerEvent"),
+    branch = cms.string("triggerObjectsIsoMu22Eta2p1"),
+    hltPath = cms.string("HLT_IsoMu22_eta2p1_v"),
+    inputIsStandAlone = cms.bool(False),
+    storeOnlyIfFired = cms.bool(False)
+    )
 
 
 process.icIsoMu20ObjectProducer = producers.icTriggerObjectProducer.clone(
@@ -2070,7 +2070,7 @@ process.icTriggerObjectSequence += cms.Sequence(
       process.icIsoMu22ObjectProducer+
       process.icIsoMu18ObjectProducer+
       process.icIsoMu20ObjectProducer+
-#      process.icIsoMu22Eta2p1ObjectProducer+
+      process.icIsoMu22Eta2p1ObjectProducer+
       process.icIsoMu24ObjectProducer+
       process.icIsoMu27ObjectProducer+
       process.icIsoTkMu18ObjectProducer+


### PR DESCRIPTION
@amagnan @riccardodimaria just FYI - this stops the ICTriggerObjectProducer from crashing if you try to run it on a HLT path that doesn't exist in that particular run. This means you won't immediately notice typos in the path name (where before you did, because the code would have crashed), but this is necessary to be able to store trigger objects for HLT paths that only exist for part of the dataset (e.g. because the HLT menu changed and a trigger was added/removed)